### PR TITLE
implement leaderboard update workflow

### DIFF
--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -1,0 +1,99 @@
+name: Update Leaderboard from Artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: GitHub Actions run_id to fetch artifact from
+        required: true
+        type: string
+      artifact_name:
+        description: Artifact name (leave empty to fetch all)
+        required: false
+        default: ""
+        type: string
+      top_n:
+        description: Top N entries to render in README
+        required: false
+        default: "10"
+        type: string
+
+concurrency:
+  group: leaderboard-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun install --frozen-lockfile
+
+      - name: Download artifact from run
+        uses: dawidd6/action-download-artifact@v8
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ inputs.run_id }}
+          workflow: benchmark.yml
+          name: ${{ inputs.artifact_name }}
+          path: downloaded
+
+      - name: Locate result JSON
+        id: locate
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Prefer latest.json if present; otherwise first *.json we find.
+          file=""
+          if [ -f downloaded/latest.json ]; then
+            file="downloaded/latest.json"
+          else
+            # find under downloaded/**
+            file=$(find downloaded -type f -name 'latest.json' -print -quit || true)
+            if [ -z "$file" ]; then
+              file=$(find downloaded -type f -name '*.json' -print -quit || true)
+            fi
+          fi
+          if [ -z "$file" ]; then
+            echo "::error::No JSON file found in artifact" >&2
+            exit 1
+          fi
+          echo "json=$file" >> "$GITHUB_OUTPUT"
+          echo "Using result JSON: $file"
+
+      - name: Update leaderboard files
+        env:
+          TOP_N: ${{ inputs.top_n }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ inputs.run_id }}
+          RUN_ID: ${{ inputs.run_id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        run: bun scripts/update-leaderboard.ts "${{ steps.locate.outputs.json }}"
+
+      - name: Commit changes (README.md + leaderboard.json)
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md public/data/leaderboard.json || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(leaderboard): update from run ${{ inputs.run_id }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -4,12 +4,25 @@
 
 ## Leaderboard
 
-| Rank | Agent | Model | Success Rate | Solved | Avg Time per Correct | Result |
-|:----:|:------|:------|:--------------:|:------:|:--------------------:|:---:|
-| 🏆 1 | [codex](https://developers.openai.com/codex/cli/) | gpt-5 | **88.0%** | 22/25 | **91.7s** | [#13](https://github.com/laiso/ts-bench/actions/runs/17344734992) |
-| 2 | [claude](https://www.anthropic.com/claude-code) | claude-sonnet-4-20250514 | **72.0%** | 18/25 | **206.1s** | [#12](https://github.com/laiso/ts-bench/actions/runs/17344732069) |
+<!-- BEGIN_LEADERBOARD -->
+| Rank | Agent | Model | Success Rate | Solved | Avg Time | Result |
+|:----:|:------|:------|:--------------:|:------:|:----------:|:-----:|
+| 1 | codex | gpt-5 | **88.0%** | 22/25 | 91.7s | [#734992](https://github.com/laiso/ts-bench/actions/runs/17344734992) |
+| 2 | claude | claude-sonnet-4-20250514 | **72.0%** | 18/25 | 206.1s | [#732069](https://github.com/laiso/ts-bench/actions/runs/17344732069) |
+<!-- END_LEADERBOARD -->
 
-**TBD**
+## 🤖 Supported Agents
+
+Currently supported agents:
+
+* [Claude Code](https://www.anthropic.com/claude-code)
+* [Codex CLI](https://developers.openai.com/codex/cli/)
+* [Gemini CLI](https://cloud.google.com/gemini/docs/codeassist/gemini-cli)
+* [OpenCode](https://opencode.ai/)
+* [Goose CLI](https://block.github.io/goose/)
+* [Qwen Code](https://qwenlm.github.io/qwen-code-docs/)
+
+and [Aider](https://www.aider.com/)
 
 ## 📖 Vision & Principles
 
@@ -30,6 +43,11 @@ All benchmark results are generated and published via GitHub Actions.
 
 Each results page provides a formatted summary and downloadable artifacts containing raw data (JSON).
 
+## Documentation
+For detailed documentation, see:
+
+- [Leaderboard Operation Design](docs/leaderboard.md): Explains how the leaderboard is updated and maintained.
+
 ## 🚀 Getting Started
 
 ### Installation
@@ -49,14 +67,3 @@ bun src/index.ts --agent claude --model claude-3-5-sonnet-20240620
 # Run only the 'acronym' problem with Aider (GPT-4o)
 bun src/index.ts --agent aider --model gpt-4o --exercise acronym
 ```
-
-## 🤖 Supported Agents
-
-Currently supported agents:
-
-* `claude`
-* `goose`
-* `aider`
-* `codex`
-* `gemini`
-* `opencode`

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -1,0 +1,173 @@
+## Leaderboard Operation Design
+
+This document summarizes the final design for publishing the leaderboard in ts-bench, aiming for a "lightweight, reproducible, and transparent" process.
+
+### TL;DR
+
+- Single data source: Only the latest version is kept in `public/data/leaderboard.json` (key: `agent-model`).
+- README displays only the Top N entries, auto-generated (marker replacement). The Result column shows a Run link.
+- Raw result JSONs are not committed to the repository, but saved as GitHub Actions Artifacts.
+- Workflow separation:
+  - Benchmark run (uploads result JSON as Artifact)
+  - Update run (fetches Artifact from any run → merges into JSON → updates README & commits only 2 files)
+- README acts as a "template" with an initial table, always ensuring display.
+
+---
+
+## Architecture Overview
+
+1) Manual Benchmark Run (Execution → Artifact)
+- Run ts-bench to generate result JSONs (including `latest.json`, default: `./results`).
+- Result JSONs are not committed, but uploaded as Artifacts.
+
+2) Update Leaderboard from Artifact (Update)
+- Retrieve `latest.json` (or first `*.json` if not present) from the specified run's Artifact.
+- Upsert into `public/data/leaderboard.json` (key: `agent-model`).
+- Replace the marker section in README with a Top N table (Result column links to Run).
+- Only `README.md` and `public/data/leaderboard.json` are committed.
+
+Benefits
+- Repository size remains small (history kept in Artifacts).
+- Fast updates (Upsert into single JSON + table generation).
+- Can regenerate from any run (reproducibility & transparency).
+
+---
+
+## Data File Specification (leaderboard.json)
+
+- Path: `public/data/leaderboard.json`
+- Structure: `results` always keeps only the latest entry per `agent-model` key.
+
+```jsonc
+{
+  "lastUpdated": "2025-08-31T00:00:00.000Z",
+  "results": {
+    "codex-gpt-5": {
+      "metadata": {
+        "agent": "codex",
+        "model": "gpt-5",
+        "provider": "openai",
+        "version": "unknown",
+        "timestamp": "2025-08-30T12:30:00.000Z",
+        "exerciseCount": 25,
+        "benchmarkVersion": "1.0.0",
+        "generatedBy": "ts-bench",
+        "runUrl": "https://github.com/laiso/ts-bench/actions/runs/17344734992",
+        "runId": "17344734992",
+        "artifactName": "results-codex-gpt-5"
+      },
+      "summary": {
+        "successRate": 88.0,
+        "totalDuration": 2292500.0,
+        "avgDuration": 91700.0,
+        "successCount": 22,
+        "totalCount": 25,
+        "agentSuccessCount": 22,
+        "testSuccessCount": 22,
+        "testFailedCount": 3
+      },
+      "results": []
+    }
+  }
+}
+```
+
+Key Design
+- Default: `agent-model`. Can be extended to `agent-model-provider` if needed.
+
+---
+
+## Update Script (scripts/update-leaderboard.ts)
+
+Role
+- Validates and loads input JSON (from Artifact).
+- Upserts into `public/data/leaderboard.json` (overwrites by `agent-model`, updates `lastUpdated`).
+- Replaces the marker section in README with Top N table.
+
+Specs
+- Sort: By descending success rate → ascending average time.
+- Top count: `TOP_N` (env var, default 10).
+- Result column: Uses `RUN_URL/RUN_ID` to display as `[#<last 6 digits>]` link (if missing, show `-`).
+- If no marker, inserts table right after "## Leaderboard", or at the top if not found.
+
+Usage (local)
+```
+TOP_N=10 \
+RUN_URL="https://github.com/<org>/<repo>/actions/runs/<run_id>" \
+RUN_ID="<run_id>" \
+bun scripts/update-leaderboard.ts <path/to/result.json>
+```
+
+---
+
+## README as a Template
+
+- `README.md` contains the initial leaderboard table with markers.
+- The script only replaces the section between markers, so the table is always displayed even if not run or failed.
+
+Example (markers)
+```
+<!-- BEGIN_LEADERBOARD -->
+| Rank | Agent | Model | Success Rate | Solved | Avg Time | Result |
+|:----:|:------|:------|:--------------:|:------:|:----------:|:-----:|
+| 1 | codex | gpt-5 | **88.0%** | 22/25 | 91.7s | [#734992](https://github.com/laiso/ts-bench/actions/runs/17344734992) |
+| 2 | claude | claude-sonnet-4-20250514 | **72.0%** | 18/25 | 206.1s | [#732069](https://github.com/laiso/ts-bench/actions/runs/17344732069) |
+<!-- END_LEADERBOARD -->
+```
+
+---
+
+## GitHub Actions
+
+1) Benchmark Workflow (`.github/workflows/benchmark.yml`)
+- Runs benchmark → saves JSONs under `results/` (including `latest.json`) → uploads as Artifact only.
+
+2) Update Workflow (`.github/workflows/update-leaderboard.yml`)
+- Inputs: `run_id` (required), `artifact_name` (optional), `top_n` (optional).
+- Retrieves `latest.json` (or first `*.json`) from specified run's Artifact.
+- Injects `RUN_URL/RUN_ID/ARTIFACT_NAME` as env vars to the script.
+- Script merges into JSON → replaces README section → commits only 2 files.
+- Runs serially: `concurrency: group: leaderboard-update` to avoid conflicts.
+
+---
+
+## Operation Steps
+
+1. Run the benchmark
+- Actions → Manual Benchmark Run → specify inputs → after completion, Artifact (`results-<agent>-<model>`) is generated on the Run page.
+
+2. Update the leaderboard
+- Actions → Update Leaderboard from Artifact → specify `run_id` (from URL) and `artifact_name` (optional) → run.
+- After execution, only `README.md` and `public/data/leaderboard.json` are committed/updated.
+
+---
+
+## Guardrails / Notes
+
+- Conflict avoidance: Update workflow runs serially. If failed, rerun to restore consistency.
+- Schema compatibility: Fields are added for backward compatibility (e.g., `metadata.runUrl`).
+- Key design: Default is `agent-model`, can be extended with `provider` if needed.
+- Display policy: README shows only Top N. All entries are in `public/data/leaderboard.json`. Result column shows `-` if Run URL is missing.
+
+---
+
+## Local Verification
+
+```
+# Check README update behavior with sample JSON
+bun scripts/update-leaderboard.ts src/benchmark/__tests__/sample/results/latest.json
+
+# Test with custom Top N and links
+TOP_N=5 RUN_URL="https://github.com/<org>/<repo>/actions/runs/123456" RUN_ID=123456 \
+  bun scripts/update-leaderboard.ts src/benchmark/__tests__/sample/results/latest.json
+```
+
+---
+
+## Future Extensions
+
+- Visualization on static site (graphs, filters, history comparison).
+- Bulk regeneration from multiple run Artifacts (history-based reconstruction).
+- Sub-ranking by model or period.
+
+This design keeps the repository clean while enabling fast and reproducible leaderboard updates.

--- a/public/data/leaderboard.json
+++ b/public/data/leaderboard.json
@@ -1,0 +1,57 @@
+{
+  "lastUpdated": "2025-08-31T00:00:00.000Z",
+  "results": {
+    "codex-gpt-5": {
+      "metadata": {
+        "agent": "codex",
+        "model": "gpt-5",
+        "provider": "openai",
+        "version": "unknown",
+        "timestamp": "2025-08-30T12:30:00.000Z",
+        "exerciseCount": 25,
+        "benchmarkVersion": "1.0.0",
+        "generatedBy": "ts-bench",
+        "runUrl": "https://github.com/laiso/ts-bench/actions/runs/17344734992",
+        "runId": "17344734992",
+        "artifactName": "results-codex-gpt-5"
+      },
+      "summary": {
+        "successRate": 88.0,
+        "totalDuration": 2292500.0,
+        "avgDuration": 91700.0,
+        "successCount": 22,
+        "totalCount": 25,
+        "agentSuccessCount": 22,
+        "testSuccessCount": 22,
+        "testFailedCount": 3
+      },
+      "results": []
+    },
+    "claude-claude-sonnet-4-20250514": {
+      "metadata": {
+        "agent": "claude",
+        "model": "claude-sonnet-4-20250514",
+        "provider": "anthropic",
+        "version": "unknown",
+        "timestamp": "2025-08-30T12:00:00.000Z",
+        "exerciseCount": 25,
+        "benchmarkVersion": "1.0.0",
+        "generatedBy": "ts-bench",
+        "runUrl": "https://github.com/laiso/ts-bench/actions/runs/17344732069",
+        "runId": "17344732069",
+        "artifactName": "results-claude-claude-sonnet-4-20250514"
+      },
+      "summary": {
+        "successRate": 72.0,
+        "totalDuration": 5152500.0,
+        "avgDuration": 206100.0,
+        "successCount": 18,
+        "totalCount": 25,
+        "agentSuccessCount": 18,
+        "testSuccessCount": 18,
+        "testFailedCount": 7
+      },
+      "results": []
+    }
+  }
+}

--- a/scripts/update-leaderboard.ts
+++ b/scripts/update-leaderboard.ts
@@ -1,0 +1,178 @@
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { dirname } from 'path';
+import { existsSync } from 'fs';
+
+interface SavedBenchmarkResult {
+  metadata: {
+    agent: string;
+    model: string;
+    provider: string;
+    version?: string;
+    timestamp: string;
+    exerciseCount?: number;
+    benchmarkVersion?: string;
+    generatedBy?: string;
+    totalExercises?: number;
+    runUrl?: string;
+    runId?: string;
+    artifactName?: string;
+  };
+  summary: {
+    successRate: number;
+    totalDuration: number;
+    avgDuration: number;
+    successCount: number;
+    totalCount: number;
+    agentSuccessCount: number;
+    testSuccessCount: number;
+    testFailedCount: number;
+  };
+  results: unknown[];
+}
+
+interface LeaderboardData {
+  lastUpdated: string;
+  results: Record<string, SavedBenchmarkResult>; // key: agent-model
+}
+
+const LEADERBOARD_PATH = './public/data/leaderboard.json';
+const README_PATH = './README.md';
+const TOP_N = Number(process.env.TOP_N ?? '10');
+
+async function main() {
+  const newResultPath = process.argv[2];
+  if (!newResultPath) {
+    console.error('Usage: bun scripts/update-leaderboard.ts <path/to/new-result.json>');
+    process.exit(1);
+  }
+
+  let leaderboardData: LeaderboardData;
+  if (existsSync(LEADERBOARD_PATH)) {
+    leaderboardData = JSON.parse(await readFile(LEADERBOARD_PATH, 'utf-8')) as LeaderboardData;
+  } else {
+    leaderboardData = { lastUpdated: new Date().toISOString(), results: {} };
+  }
+
+  const newResult: SavedBenchmarkResult = JSON.parse(await readFile(newResultPath, 'utf-8')) as SavedBenchmarkResult;
+  validateResult(newResult);
+  const key = `${newResult.metadata.agent}-${newResult.metadata.model}`;
+
+  const RUN_URL = process.env.RUN_URL;
+  const RUN_ID = process.env.RUN_ID;
+  const ARTIFACT_NAME = process.env.ARTIFACT_NAME;
+  const merged: SavedBenchmarkResult = {
+    ...newResult,
+    metadata: {
+      ...newResult.metadata,
+      runUrl: RUN_URL || newResult.metadata.runUrl,
+      runId: RUN_ID || newResult.metadata.runId,
+      artifactName: ARTIFACT_NAME || newResult.metadata.artifactName,
+    },
+  };
+
+  leaderboardData.results[key] = merged;
+  leaderboardData.lastUpdated = new Date().toISOString();
+
+  await ensureDirectoryExists(LEADERBOARD_PATH);
+  await writeFile(LEADERBOARD_PATH, JSON.stringify(leaderboardData, null, 2), 'utf-8');
+  console.log(`✅ Updated: ${LEADERBOARD_PATH}`);
+
+  const markdownTable = buildTopTable(leaderboardData, TOP_N);
+  await updateReadmeWithTable(markdownTable);
+  console.log('✅ README.md updated with Top leaderboard');
+}
+
+function validateResult(r: SavedBenchmarkResult) {
+  if (!r || !r.metadata || !r.summary) {
+    throw new Error('Invalid result JSON: missing metadata/summary');
+  }
+  const requiredMeta = ['agent', 'model', 'provider', 'timestamp'] as const;
+  for (const k of requiredMeta) {
+    if (!(k in r.metadata)) throw new Error(`Invalid result JSON: metadata.${k} missing`);
+  }
+  const requiredSummary = ['successRate', 'avgDuration', 'successCount', 'totalCount'] as const;
+  for (const k of requiredSummary) {
+    if (!(k in r.summary)) throw new Error(`Invalid result JSON: summary.${k} missing`);
+  }
+}
+
+function buildTopTable(data: LeaderboardData, topN: number): string {
+  const records = Object.values(data.results);
+  const sorted = records
+    .slice()
+    .sort((a, b) => {
+      if (b.summary.successRate !== a.summary.successRate) {
+        return b.summary.successRate - a.summary.successRate;
+      }
+      return a.summary.avgDuration - b.summary.avgDuration;
+    })
+    .slice(0, Math.max(0, topN));
+
+  const header = '| Rank | Agent | Model | Success Rate | Solved | Avg Time | Result |';
+  const separator = '|:----:|:------|:------|:--------------:|:------:|:----------:|:-----:|';
+
+  const rows = sorted.map((r, i) => {
+    const rank = i + 1;
+    const agent = r.metadata.agent;
+    const model = r.metadata.model;
+    const successRate = `${Number(r.summary.successRate).toFixed(1)}%`;
+    const solved = `${r.summary.successCount}/${r.summary.totalCount}`;
+    const avgTime = `${(Number(r.summary.avgDuration) / 1000).toFixed(1)}s`;
+    const runUrl = (r.metadata as any).runUrl as string | undefined;
+    const runId = (r.metadata as any).runId as string | undefined;
+    let label = 'run';
+    if (runId && /\d+/.test(runId)) {
+      label = `#${runId.slice(-6)}`;
+    } else if (runUrl) {
+      const m = runUrl.match(/runs\/(\d+)/);
+      if (m) label = `#${m[1].slice(-6)}`;
+    }
+    const resultCell = runUrl ? `[${label}](${runUrl})` : '-';
+    return `| ${rank} | ${agent} | ${model} | **${successRate}** | ${solved} | ${avgTime} | ${resultCell} |`;
+  });
+
+  return [header, separator, ...rows].join('\n');
+}
+
+async function updateReadmeWithTable(table: string) {
+  const begin = '<!-- BEGIN_LEADERBOARD -->';
+  const end = '<!-- END_LEADERBOARD -->';
+  const block = `${begin}\n${table}\n${end}`;
+
+  const content = await readFile(README_PATH, 'utf-8');
+
+  const markerRe = new RegExp(`${escapeRegExp(begin)}[\n\r\s\S]*?${escapeRegExp(end)}`);
+  if (markerRe.test(content)) {
+    const replaced = content.replace(markerRe, block);
+    await writeFile(README_PATH, replaced, 'utf-8');
+    return;
+  }
+
+  const lines = content.split(/\r?\n/);
+  const headerIdx = lines.findIndex((l) => /^##\s+Leaderboard\s*$/i.test(l.trim()));
+  if (headerIdx >= 0) {
+    const before = lines.slice(0, headerIdx + 1).join('\n');
+    const after = lines.slice(headerIdx + 1).join('\n');
+    const combined = `${before}\n\n${block}\n\n${after}`;
+    await writeFile(README_PATH, combined, 'utf-8');
+    return;
+  }
+
+  await writeFile(README_PATH, `${block}\n\n${content}`, 'utf-8');
+}
+
+async function ensureDirectoryExists(filePath: string) {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+}
+
+function escapeRegExp(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Leaderboard Operation Design

This document summarizes the final design for publishing the leaderboard in ts-bench, aiming for a "lightweight, reproducible, and transparent" process.

### TL;DR

- Single data source: Only the latest version is kept in `public/data/leaderboard.json` (key: `agent-model`).
- README displays only the Top N entries, auto-generated (marker replacement). The Result column shows a Run link.
- Raw result JSONs are not committed to the repository, but saved as GitHub Actions Artifacts.
- Workflow separation:
  - Benchmark run (uploads result JSON as Artifact)
  - Update run (fetches Artifact from any run → merges into JSON → updates README & commits only 2 files)
- README acts as a "template" with an initial table, always ensuring display.

---

## Architecture Overview

1) Manual Benchmark Run (Execution → Artifact)
- Run ts-bench to generate result JSONs (including `latest.json`, default: `./results`).
- Result JSONs are not committed, but uploaded as Artifacts.

2) Update Leaderboard from Artifact (Update)
- Retrieve `latest.json` (or first `*.json` if not present) from the specified run's Artifact.
- Upsert into `public/data/leaderboard.json` (key: `agent-model`).
- Replace the marker section in README with a Top N table (Result column links to Run).
- Only `README.md` and `public/data/leaderboard.json` are committed.

Benefits
- Repository size remains small (history kept in Artifacts).
- Fast updates (Upsert into single JSON + table generation).
- Can regenerate from any run (reproducibility & transparency).

---

## Data File Specification (leaderboard.json)

- Path: `public/data/leaderboard.json`
- Structure: `results` always keeps only the latest entry per `agent-model` key.

```jsonc
{
  "lastUpdated": "2025-08-31T00:00:00.000Z",
  "results": {
    "codex-gpt-5": {
      "metadata": {
        "agent": "codex",
        "model": "gpt-5",
        "provider": "openai",
        "version": "unknown",
        "timestamp": "2025-08-30T12:30:00.000Z",
        "exerciseCount": 25,
        "benchmarkVersion": "1.0.0",
        "generatedBy": "ts-bench",
        "runUrl": "https://github.com/laiso/ts-bench/actions/runs/17344734992",
        "runId": "17344734992",
        "artifactName": "results-codex-gpt-5"
      },
      "summary": {
        "successRate": 88.0,
        "totalDuration": 2292500.0,
        "avgDuration": 91700.0,
        "successCount": 22,
        "totalCount": 25,
        "agentSuccessCount": 22,
        "testSuccessCount": 22,
        "testFailedCount": 3
      },
      "results": []
    }
  }
}
```

Key Design
- Default: `agent-model`. Can be extended to `agent-model-provider` if needed.

---

## Update Script (scripts/update-leaderboard.ts)

Role
- Validates and loads input JSON (from Artifact).
- Upserts into `public/data/leaderboard.json` (overwrites by `agent-model`, updates `lastUpdated`).
- Replaces the marker section in README with Top N table.

Specs
- Sort: By descending success rate → ascending average time.
- Top count: `TOP_N` (env var, default 10).
- Result column: Uses `RUN_URL/RUN_ID` to display as `[#<last 6 digits>]` link (if missing, show `-`).
- If no marker, inserts table right after "## Leaderboard", or at the top if not found.

Usage (local)
```
TOP_N=10 \
RUN_URL="https://github.com/<org>/<repo>/actions/runs/<run_id>" \
RUN_ID="<run_id>" \
bun scripts/update-leaderboard.ts <path/to/result.json>
```

---

## README as a Template

- `README.md` contains the initial leaderboard table with markers.
- The script only replaces the section between markers, so the table is always displayed even if not run or failed.

Example (markers)
```
<!-- BEGIN_LEADERBOARD -->
| Rank | Agent | Model | Success Rate | Solved | Avg Time | Result |
|:----:|:------|:------|:--------------:|:------:|:----------:|:-----:|
| 1 | codex | gpt-5 | **88.0%** | 22/25 | 91.7s | [#734992](https://github.com/laiso/ts-bench/actions/runs/17344734992) |
| 2 | claude | claude-sonnet-4-20250514 | **72.0%** | 18/25 | 206.1s | [#732069](https://github.com/laiso/ts-bench/actions/runs/17344732069) |
<!-- END_LEADERBOARD -->
```

---

## GitHub Actions

1) Benchmark Workflow (`.github/workflows/benchmark.yml`)
- Runs benchmark → saves JSONs under `results/` (including `latest.json`) → uploads as Artifact only.

2) Update Workflow (`.github/workflows/update-leaderboard.yml`)
- Inputs: `run_id` (required), `artifact_name` (optional), `top_n` (optional).
- Retrieves `latest.json` (or first `*.json`) from specified run's Artifact.
- Injects `RUN_URL/RUN_ID/ARTIFACT_NAME` as env vars to the script.
- Script merges into JSON → replaces README section → commits only 2 files.
- Runs serially: `concurrency: group: leaderboard-update` to avoid conflicts.

---

## Operation Steps

1. Run the benchmark
- Actions → Manual Benchmark Run → specify inputs → after completion, Artifact (`results-<agent>-<model>`) is generated on the Run page.

2. Update the leaderboard
- Actions → Update Leaderboard from Artifact → specify `run_id` (from URL) and `artifact_name` (optional) → run.
- After execution, only `README.md` and `public/data/leaderboard.json` are committed/updated.

---

## Guardrails / Notes

- Conflict avoidance: Update workflow runs serially. If failed, rerun to restore consistency.
- Schema compatibility: Fields are added for backward compatibility (e.g., `metadata.runUrl`).
- Key design: Default is `agent-model`, can be extended with `provider` if needed.
- Display policy: README shows only Top N. All entries are in `public/data/leaderboard.json`. Result column shows `-` if Run URL is missing.

---

## Local Verification

```
# Check README update behavior with sample JSON
bun scripts/update-leaderboard.ts src/benchmark/__tests__/sample/results/latest.json

# Test with custom Top N and links
TOP_N=5 RUN_URL="https://github.com/<org>/<repo>/actions/runs/123456" RUN_ID=123456 \
  bun scripts/update-leaderboard.ts src/benchmark/__tests__/sample/results/latest.json
```

---

## Future Extensions

- Visualization on static site (graphs, filters, history comparison).
- Bulk regeneration from multiple run Artifacts (history-based reconstruction).
- Sub-ranking by model or period.

This design keeps the repository clean while enabling fast and reproducible leaderboard updates.
