### PR TITLE
feat(leaderboard): Update with results from run 17366415419

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@
 <!-- BEGIN_LEADERBOARD -->
 | Rank | Agent | Model | Success Rate | Solved | Avg Time | Result |
 |:----:|:------|:------|:--------------:|:------:|:----------:|:-----:|
-| 1 | gemini | gemini-2.5-pro | **92.0%** | 23/25 | 168.5s | [#052819](https://github.com/laiso/ts-bench/actions/runs/17351052819) |
-| 2 | codex | gpt-5 | **88.0%** | 22/25 | 91.7s | [#734992](https://github.com/laiso/ts-bench/actions/runs/17344734992) |
-| 3 | opencode | opencode/grok-code | **88.0%** | 22/25 | 97.0s | [#083421](https://github.com/laiso/ts-bench/actions/runs/17355083421) |
-| 4 | claude | claude-sonnet-4-20250514 | **72.0%** | 18/25 | 206.1s | [#732069](https://github.com/laiso/ts-bench/actions/runs/17344732069) |
-| 5 | qwen | qwen3-coder-plus | **64.0%** | 16/25 | 123.9s | [#246268](https://github.com/laiso/ts-bench/actions/runs/17356246268) |
-| 6 | claude | deepseek-reasoner | **32.0%** | 8/25 | 284.0s | [#196715](https://github.com/laiso/ts-bench/actions/runs/17357196715) |
+| 1 | opencode | openai/gpt-5 | **96.0%** | 24/25 | 64.8s | [#415419](https://github.com/yukukotani/ts-bench/actions/runs/17366415419) |
+| 2 | gemini | gemini-2.5-pro | **92.0%** | 23/25 | 168.5s | [#052819](https://github.com/laiso/ts-bench/actions/runs/17351052819) |
+| 3 | codex | gpt-5 | **88.0%** | 22/25 | 91.7s | [#734992](https://github.com/laiso/ts-bench/actions/runs/17344734992) |
+| 4 | opencode | opencode/grok-code | **88.0%** | 22/25 | 97.0s | [#083421](https://github.com/laiso/ts-bench/actions/runs/17355083421) |
+| 5 | claude | claude-sonnet-4-20250514 | **72.0%** | 18/25 | 206.1s | [#732069](https://github.com/laiso/ts-bench/actions/runs/17344732069) |
+| 6 | qwen | qwen3-coder-plus | **64.0%** | 16/25 | 123.9s | [#246268](https://github.com/laiso/ts-bench/actions/runs/17356246268) |
+| 7 | claude | deepseek-reasoner | **32.0%** | 8/25 | 284.0s | [#196715](https://github.com/laiso/ts-bench/actions/runs/17357196715) |
 <!-- END_LEADERBOARD -->
+
+
+
 
 ## 🤖 Supported Agents
 

--- a/public/data/leaderboard.json
+++ b/public/data/leaderboard.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2025-08-31T14:34:05.370Z",
+  "lastUpdated": "2025-09-01T03:54:40.002Z",
   "results": {
     "codex-gpt-5": {
       "metadata": {
@@ -1111,6 +1111,259 @@
           "agentDuration": 300420,
           "testDuration": 9253,
           "totalDuration": 309684
+        }
+      ]
+    },
+    "opencode-openai/gpt-5": {
+      "metadata": {
+        "agent": "opencode",
+        "model": "openai/gpt-5",
+        "provider": "openai",
+        "version": "0.5.29",
+        "timestamp": "2025-09-01T03:29:58.682Z",
+        "exerciseCount": 25,
+        "benchmarkVersion": "1.0.0",
+        "generatedBy": "ts-bench",
+        "runUrl": "https://github.com/yukukotani/ts-bench/actions/runs/17366415419",
+        "runId": "17366415419",
+        "artifactName": "benchmark-results"
+      },
+      "summary": {
+        "successRate": 96,
+        "totalDuration": 1619762,
+        "avgDuration": 64790.5,
+        "successCount": 24,
+        "totalCount": 25,
+        "agentSuccessCount": 25,
+        "testSuccessCount": 24,
+        "testFailedCount": 1
+      },
+      "results": [
+        {
+          "exercise": "acronym",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 125542,
+          "testDuration": 7173,
+          "totalDuration": 132863
+        },
+        {
+          "exercise": "anagram",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 31380,
+          "testDuration": 7295,
+          "totalDuration": 38686
+        },
+        {
+          "exercise": "bank-account",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 38131,
+          "testDuration": 7220,
+          "totalDuration": 45364
+        },
+        {
+          "exercise": "binary-search",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 28437,
+          "testDuration": 7222,
+          "totalDuration": 35672
+        },
+        {
+          "exercise": "binary-search-tree",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 32664,
+          "testDuration": 7192,
+          "totalDuration": 39868
+        },
+        {
+          "exercise": "bowling",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 34593,
+          "testDuration": 7504,
+          "totalDuration": 42109
+        },
+        {
+          "exercise": "complex-numbers",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 78611,
+          "testDuration": 7519,
+          "totalDuration": 86142
+        },
+        {
+          "exercise": "connect",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 48998,
+          "testDuration": 7218,
+          "totalDuration": 56228
+        },
+        {
+          "exercise": "crypto-square",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 52785,
+          "testDuration": 7302,
+          "totalDuration": 60097
+        },
+        {
+          "exercise": "diamond",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 36241,
+          "testDuration": 7271,
+          "totalDuration": 43524
+        },
+        {
+          "exercise": "dnd-character",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 35278,
+          "testDuration": 7280,
+          "totalDuration": 42570
+        },
+        {
+          "exercise": "flatten-array",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 35126,
+          "testDuration": 7304,
+          "totalDuration": 42441
+        },
+        {
+          "exercise": "food-chain",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 33396,
+          "testDuration": 7270,
+          "totalDuration": 40677
+        },
+        {
+          "exercise": "house",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 34857,
+          "testDuration": 7330,
+          "totalDuration": 42198
+        },
+        {
+          "exercise": "pascals-triangle",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 34146,
+          "testDuration": 7405,
+          "totalDuration": 41562
+        },
+        {
+          "exercise": "rational-numbers",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 37463,
+          "testDuration": 7551,
+          "totalDuration": 45025
+        },
+        {
+          "exercise": "react",
+          "agentSuccess": true,
+          "testSuccess": false,
+          "overallSuccess": false,
+          "testError": "STDOUT: \u001b[94m➤\u001b[39m \u001b[94m➤\u001b[39m \u001b[90m::group::Resolution step\n::endgroup::\n\u001b[94m➤\u001b[39m \u001b[90m\u001b[94m➤\u001b[39m \u001b[90m::group::Post-resolution validation\n\u001b[93m➤\u001b[39m YN0002: │ \u001b[38;5;166m@exercism/\u001b[39m\u001b[38;5;173mtypescript-react\u001b[39m\u001b[38;5;111m@\u001b[39m\u001b[38;5;111mworkspace:.\u001b[39m doesn't provide \u001b[38;5;166m@babel/\u001b[39m\u001b[38;5;173mcore\u001b[39m (\u001b[38;5;111mp31db9\u001b[39m), requested by \u001b[38;5;173mbabel-jest\u001b[39m.\n\u001b[93m➤\u001b[39m YN0086: │ Some peer dependencies are incorrectly met by your project; run \u001b[38;5;111myarn explain peer-requirements <hash>\u001b[39m for details, where \u001b[38;5;111m<hash>\u001b[39m is the six-letter p-prefixed code.\n\u001b[93m➤\u001b[39m YN0086: │ Some peer dependencies are incorrectly met by dependencies; run \u001b[38;5;111myarn explain peer-requirements\u001b[39m for details.\n::endgroup::\n\u001b[94m➤\u001b[39m \u001b[90m\u001b[94m➤\u001b[39m \u001b[90m::group::Fetch step\n::endgroup::\n\u001b[94m➤\u001b[39m \u001b[90m\u001b[94m➤\u001b[39m \u001b[90m::group::Link step\n\u001b[93m➤\u001b[39m ::endgroup::\n\u001b[94m➤\u001b[39m \u001b[90m\u001b[93m➤\u001b[39m [tests] tsc: ✅, tstyche: ❌, jest: ✅, \n[tests] tsc (compile)\n[tests] tstyche (implementation tests)\n\nSTDERR: ",
+          "agentDuration": 195115,
+          "testDuration": 7551,
+          "totalDuration": 202679
+        },
+        {
+          "exercise": "rectangles",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 43259,
+          "testDuration": 7417,
+          "totalDuration": 50689
+        },
+        {
+          "exercise": "relative-distance",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 40379,
+          "testDuration": 7428,
+          "totalDuration": 47817
+        },
+        {
+          "exercise": "robot-name",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 120384,
+          "testDuration": 23653,
+          "totalDuration": 144048
+        },
+        {
+          "exercise": "spiral-matrix",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 27971,
+          "testDuration": 7347,
+          "totalDuration": 35329
+        },
+        {
+          "exercise": "transpose",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 35277,
+          "testDuration": 7478,
+          "totalDuration": 42766
+        },
+        {
+          "exercise": "two-bucket",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 136316,
+          "testDuration": 7494,
+          "totalDuration": 143821
+        },
+        {
+          "exercise": "variable-length-quantity",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 29650,
+          "testDuration": 7511,
+          "totalDuration": 37174
+        },
+        {
+          "exercise": "wordy",
+          "agentSuccess": true,
+          "testSuccess": true,
+          "overallSuccess": true,
+          "agentDuration": 72895,
+          "testDuration": 7506,
+          "totalDuration": 80413
         }
       ]
     }


### PR DESCRIPTION
I'm not sure whether you're accepting external results, but let me share this. Feel free to close it.

🚀 New Entry: `opencode-openai/gpt-5` entered Leaderboard at rank 1
- Leaderboard Rank: N/A -> 1
- Success Rate: 96.0% (was N/A)
- Avg Time: 64.8s (was N/A)
- Ref: https://github.com/yukukotani/ts-bench/actions/runs/17366415419