### PR TITLE
Fix Docker execution working directory issue for exercise tests

### DIFF
--- a/src/runners/test-only.ts
+++ b/src/runners/test-only.ts
@@ -23,7 +23,7 @@ export class TestOnlyRunner {
             }
 
             const useDocker = config.useDocker ?? true;
-            const execOptions = useDocker ? { timeout: config.timeout } : { cwd: join(process.cwd(), exercisePath), timeout: config.timeout };
+            const execOptions = { cwd: join(process.cwd(), exercisePath), timeout: config.timeout };
             const result = await this.executor.execute(testArgs, execOptions);
             const duration = Date.now() - startTime;
 

--- a/src/runners/test.ts
+++ b/src/runners/test.ts
@@ -20,7 +20,7 @@ export class TestRunner {
                 this.logger.logTestCommand(testArgs);
             }
 
-            const execOptions = useDocker ? { timeout: config.timeout } : { cwd: join(process.cwd(), exercisePath), timeout: config.timeout };
+            const execOptions = { cwd: join(process.cwd(), exercisePath), timeout: config.timeout };
             const result = await this.executor.execute(testArgs, execOptions);
             const duration = Date.now() - startTime;
 


### PR DESCRIPTION
## 🐛 Problem Description

When running benchmarks with Docker enabled, the test execution was running from the repository root instead of the exercise directory. This caused a critical issue where:

- **Docker execution**: Benchmark tool's own tests were executed (e.g., `src/benchmark/__tests__/*.test.ts`) ❌
- **Local execution**: Exercise tests were correctly executed (e.g., `@exercism/typescript-wordy`) ✅

This resulted in **completely meaningless benchmark results** when using Docker, as agents' programming capabilities were not being evaluated.

## 🔍 Root Cause

The issue was in `src/runners/test.ts` and `src/runners/test-only.ts` where `execOptions` was missing the `cwd` parameter for Docker execution:

```typescript
// Before (problematic)
const execOptions = useDocker 
    ? { timeout: config.timeout }                              // ❌ Missing cwd
    : { cwd: join(process.cwd(), exercisePath), timeout: config.timeout };
```

## ✅ Solution

Fixed `execOptions` to always include the correct working directory:

```typescript
// After (fixed)
const execOptions = { 
    cwd: join(process.cwd(), exercisePath), 
    timeout: config.timeout 
};
```

## 🧪 Verification

Tested with `codex` agent on `wordy` exercise:

| Execution Mode | Test Target | Result |
|----------------|-------------|---------|
| **Docker (Before)** | `src/benchmark/__tests__/reporter.test.ts` | ❌ Wrong tests (14 pass) |
| **Docker (After)** | `@exercism/typescript-wordy@workspace` | ✅ Correct tests |
| **Local** | `@exercism/typescript-wordy@workspace` | ✅ Always worked correctly |

## 🔧 Files Changed

- `src/runners/test.ts`: Fixed `execOptions` to always include `cwd`
- `src/runners/test-only.ts`: Fixed `execOptions` to always include `cwd`

This fix ensures that benchmark results accurately reflect agent programming capabilities regardless of execution environment.
