### PR TITLE
Fix agent version detection when running via Docker

### DIFF
--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -33,7 +33,7 @@ export class BenchmarkRunner {
         if (!agentVersion) {
             console.log(`🔍 Detecting ${args.agent} version...`);
             const versionDetector = new VersionDetector();
-            agentVersion = await versionDetector.detectAgentVersion(args.agent);
+            agentVersion = await versionDetector.detectAgentVersion(args.agent, { useDocker: args.useDocker });
             console.log(`📦 Detected ${args.agent} version: ${agentVersion}\n`);
         } else {
             console.log(`📦 Using specified ${args.agent} version: ${agentVersion}\n`);


### PR DESCRIPTION
Summary

Currently, even when benchmarks run inside Docker, the harness records the host machine’s CLI version. Update the detection so it queries each agent inside the container and saves that version, ensuring the stored metadata reflects the actual Docker runtime.
  
- When --docker is passed, call docker run --rm ts-bench-container <agent> --version (container name configurable) to capture the in-container version for every agent.
- Keep the original host-side detection path for non-docker runs to avoid unnecessary container invocations.