### PR TITLE
fix(codex): Rename OPENAI_API_KEY to CODEX_API_KEY for clarity

### DIFF
--- a/src/agents/builders/codex.ts
+++ b/src/agents/builders/codex.ts
@@ -1,6 +1,6 @@
 import type { AgentBuilder, AgentConfig } from '../types';
 import { BaseAgentBuilder } from '../base';
-import { requireEnv } from '../../utils/env';
+import { requireAnyEnv, requireEnv } from '../../utils/env';
 
 export class CodexAgentBuilder extends BaseAgentBuilder implements AgentBuilder {
     constructor(agentConfig: AgentConfig) {
@@ -15,10 +15,15 @@ export class CodexAgentBuilder extends BaseAgentBuilder implements AgentBuilder 
                 return {
                     OPENROUTER_API_KEY: requireEnv('OPENROUTER_API_KEY', 'Missing OPENROUTER_API_KEY for Codex (OpenRouter) provider')
                 };
-            case 'openai':
+            case 'openai': {
+                const { value } = requireAnyEnv(
+                    ['CODEX_API_KEY', 'OPENAI_API_KEY'],
+                    'Missing CODEX_API_KEY or OPENAI_API_KEY for Codex (OpenAI) provider'
+                );
                 return {
-                    OPENAI_API_KEY: requireEnv('OPENAI_API_KEY', 'Missing OPENAI_API_KEY for Codex (OpenAI) provider')
+                    CODEX_API_KEY: value
                 };
+            }
             default:
                 throw new Error(`Unsupported provider for Codex: ${provider}`);
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches OpenAI provider to read CODEX_API_KEY (falling back to OPENAI_API_KEY) and export it as CODEX_API_KEY.
> 
> - **Agents / Codex**
>   - **Env handling (OpenAI provider)**: Accept either `CODEX_API_KEY` or `OPENAI_API_KEY` via `requireAnyEnv`, and expose it as `CODEX_API_KEY`.
>   - Import `requireAnyEnv` to support the new lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 289b4ec6b40486248cefb97a64199c6a117a5a92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->