### PR TITLE
Running Claude Code via OpenRouter proxy

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -81,6 +81,21 @@
 
 ---
 
+## Claude (OpenRouter)
+
+- Required env: `OPENROUTER_API_KEY`
+- Optional env: `ANTHROPIC_BASE_URL` (default: `https://openrouter.ai/api`)
+- Claude Code auth token is derived from `OPENROUTER_API_KEY`; `ANTHROPIC_API_KEY` is forced to empty to avoid conflicts.
+
+Example:
+
+```
+export OPENROUTER_API_KEY=sk-or-...
+bun src/index.ts --agent claude --provider openrouter --model <openrouter-model-id> --exercise acronym --docker
+```
+
+---
+
 ## Directories and I/O
 
 - Exercise root: `exercism-typescript` (`EXERCISM_PRACTICE_PATH`)

--- a/src/agents/builders/__tests__/claude.test.ts
+++ b/src/agents/builders/__tests__/claude.test.ts
@@ -23,4 +23,25 @@ describe('ClaudeAgentBuilder', () => {
 
         process.env.ANTHROPIC_API_KEY = prev;
     });
+
+    it('buildCommand should map OpenRouter env vars for Claude', async () => {
+        const prevOpenRouterKey = process.env.OPENROUTER_API_KEY;
+        const prevAnthropicKey = process.env.ANTHROPIC_API_KEY;
+        const prevAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+
+        process.env.OPENROUTER_API_KEY = 'openrouter-key';
+        process.env.ANTHROPIC_API_KEY = 'should-be-ignored';
+        process.env.ANTHROPIC_BASE_URL = 'https://example.com/anthropic';
+
+        const builder = new ClaudeAgentBuilder({ ...config, provider: 'openrouter' });
+        const cmd = await builder.buildCommand('Test instructions');
+
+        expect(cmd.env?.ANTHROPIC_API_KEY).toBe('');
+        expect(cmd.env?.ANTHROPIC_AUTH_TOKEN).toBe('openrouter-key');
+        expect(cmd.env?.ANTHROPIC_BASE_URL).toBe('https://example.com/anthropic');
+
+        process.env.OPENROUTER_API_KEY = prevOpenRouterKey;
+        process.env.ANTHROPIC_API_KEY = prevAnthropicKey;
+        process.env.ANTHROPIC_BASE_URL = prevAnthropicBaseUrl;
+    });
 });

--- a/src/agents/builders/claude.ts
+++ b/src/agents/builders/claude.ts
@@ -40,6 +40,13 @@ export class ClaudeAgentBuilder extends BaseAgentBuilder implements AgentBuilder
                 env.ANTHROPIC_BASE_URL = 'https://api.z.ai/api/anthropic';
                 break;
             }
+            case 'openrouter': {
+                const value = requireEnv('OPENROUTER_API_KEY', 'Missing OPENROUTER_API_KEY for Claude (OpenRouter) provider');
+                env.ANTHROPIC_API_KEY = '';
+                env.ANTHROPIC_AUTH_TOKEN = value;
+                env.ANTHROPIC_BASE_URL = process.env.ANTHROPIC_BASE_URL || 'https://openrouter.ai/api';
+                break;
+            }
             default: {
                 const { value } = requireAnyEnv(
                     ['ANTHROPIC_API_KEY', 'DASHSCOPE_API_KEY'],


### PR DESCRIPTION
## Summary
Implemented support to run Claude Code via an OpenRouter proxy and validated with manual benchmarks. Confirmed that some models work and others do not.

https://openrouter.ai/docs/guides/guides/claude-code-integration

## Implementation
- Added Claude `openrouter` provider and aligned Claude Code environment variables with OpenRouter requirements
- Added unit tests for OpenRouter
- Updated documentation with usage steps

## Tests
- Ran manual benchmarks (workflow: `benchmark.yml`)
- Example command:
  - `bun src/index.ts --agent claude --provider openrouter --model <model> --exercise acronym --docker`

## Results
- Bottom line: Some models worked; others did not
- Failed (in this harness):
  - gemini
  - gpt-oss
  - devstral
- Likely usable (feels like a degraded sonnet/haiku):
  - [glm](https://github.com/laiso/ts-bench/actions/runs/20388831111)
  - grok-code
  - minimax
  - codex-mini
- Models tried ([from workflow](https://github.com/laiso/ts-bench/actions/workflows/benchmark.yml)):
  - [openai/gpt-5.1-codex-mini](https://github.com/laiso/ts-bench/actions/runs/20388774108)
  - google/gemini-3-flash-preview
  - [minimax/minimax-m2](https://github.com/laiso/ts-bench/actions/runs/20388711999)
  - mistralai/devstral-2512:free
  - openai/gpt-oss-120b
  - [x-ai/grok-code-fast-1](https://github.com/laiso/ts-bench/actions/runs/20388644630/job/58594355354)
