### PR TITLE
fix(agents): cursor-agent --yolo for CI workspace trust

### DIFF
--- a/src/agents/builders/__tests__/all-agents.test.ts
+++ b/src/agents/builders/__tests__/all-agents.test.ts
@@ -68,7 +68,10 @@ describe('Agent builders invoke run-agent script', () => {
             cli: 'cursor-agent',
             builder: new CursorAgentBuilder(BASE_CONFIG),
             env: [['CURSOR_API_KEY', 'test-cursor-key'] as const],
-            assertCommand: (command) => assertRunAgent(command, 'cursor-agent')
+            assertCommand: (command) => {
+                assertRunAgent(command, 'cursor-agent');
+                expect(command.args).toContain('--yolo');
+            }
         },
         {
             cli: 'copilot',

--- a/src/agents/builders/cursor.ts
+++ b/src/agents/builders/cursor.ts
@@ -20,6 +20,8 @@ export class CursorAgentBuilder extends BaseAgentBuilder implements AgentBuilder
             'bash',
             this.config.agentScriptPath,
             'cursor-agent',
+            // Non-interactive / CI: trust workspace without prompting (see cursor-agent --help)
+            '--yolo',
             '--model',
             this.config.model,
             '-p',


### PR DESCRIPTION
## Summary

- Append **`--yolo`** to the `cursor-agent` invocation so **non-interactive** runs (e.g. GitHub Actions) skip the **Workspace Trust** prompt.
- **Scope:** `CursorAgentBuilder` only; other agents are unchanged.

## Context

CI logs showed `Workspace Trust Required` with no TTY. The Cursor CLI documents `--trust`, `--yolo`, or `-f` for trusted directories in headless environments.

## Test plan

- [x] `bun test ./src` (agent builder tests assert `--yolo` for Cursor)