### PR TITLE
fix: v2 test-only pipeline — inline services, Chrome, nvm, output truncation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,14 @@ ts-bench is a TypeScript AI Agent Benchmark CLI tool built with **Bun**. See `RE
 - Running actual benchmarks requires an AI agent CLI + API key (e.g. `ANTHROPIC_API_KEY`). Use `--test-only` or `--print-instructions` for dry-run validation without credentials.
 - Exercise test execution uses `corepack yarn` (Yarn v4). `corepack@0.29.4` must be installed globally and enabled: `npm install -g corepack@0.29.4 && corepack enable`.
 - The v2 dataset (SWE-Lancer) requires Docker and additional submodules — see `docs/environment.md`.
+
+### v2 (SWE-Lancer) Docker caveats in Cursor Cloud
+
+- Docker must be installed and `dockerd` started manually: `sudo dockerd &>/tmp/dockerd.log &`
+- Fix socket permissions after starting: `sudo chmod 666 /var/run/docker.sock`
+- The monolith image `swelancer/swelancer_x86_monolith:releasev1` is ~15 GB; first pull takes several minutes.
+- Docker requires `fuse-overlayfs` storage driver and `iptables-legacy` in this VM (see system prompt instructions for Docker-in-Docker setup).
+- v2 `--test-only` runs against unmodified Expensify code, so test failures are expected (no agent patch applied).
+- v2 tasks take 5+ minutes per exercise due to ansible setup + npm install inside the container.
+- Submodules needed: `repos/frontier-evals` and `repos/expensify-app`. Init with `git submodule update --init repos/frontier-evals repos/expensify-app`; also `mkdir -p .patches`.
+- v2 automatically enables `--docker` (see `src/utils/cli.ts` line 119).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix the v2 (SWE-Lancer) `--test-only` pipeline to work in Cursor Cloud Agent (Docker-in-Docker) environments. Five root causes identified and resolved; pipeline now reaches pytest PASSED.

## Changes

### Pipeline fixes (`docker-strategy.ts`, `index.ts`)
- Remove `(exec "$@")` pattern — replaced with single-shell command concatenation to prevent background services (nginx, pusher-fake, mitmdump) from being killed when exec replaces the shell process
- Add `ISSUE_ID` as Docker environment variable for ansible `become: true` compatibility
- Delegate v2 test command to `scripts/v2-test-runner.sh` (invoked via existing `/ts-bench-host` mount)

### `scripts/v2-test-runner.sh` (new file, version-controlled)
- Install Chrome (not included in monolith image)
- Start Xvfb, nginx, pusher-fake services
- Generate mitmproxy CA certificate inline using `/opt/conda/envs/testbed/bin/mitmdump` (because `setup_expensify.yml` deletes `/usr/local/bin/mitmdump` via `pip uninstall`, and `/root/.local/bin` is overwritten by CLI cache mount)
- Recompile webpack with applied patch + start `npm run web` with nvm sourced
- Auto-apply `.patches/$ISSUE_ID.patch` if present
- Run pytest with full output

### Docker / shell fixes (`docker.ts`, `shell.ts`)
- Remove `-i` flag from `docker run` (incompatible with `stdin: "ignore"` in spawn)
- Add explicit `stdin: "ignore"` to `BunCommandExecutor.spawn`

### Output truncation fix (`logger.ts`, `reporter.ts`)
- Change all output truncation from `.slice(0, 500)` (first 500 chars) to `.slice(-3000)` (last 3000 chars) — previous behavior showed only ansible setup logs, hiding actual test errors
- Fix duplicate stdout logging in `logAgentFailure`

### AGENTS.md
- Add v2 Docker-in-Docker caveats section for future cloud agents

## Root causes found & fixed

| # | Problem | Root cause | Fix |
|---|---|---|---|
| 1 | Background services die during test phase | `(exec "$@")` replaces shell, orphaning background jobs | Inline command concatenation |
| 2 | `mitmdump: No such file or directory` | CLI cache mount `-v cli:/root/.local` overwrites container's pipx tools | Use `/opt/conda/envs/testbed/bin/mitmdump` |
| 3 | `mitmdump` deleted after setup | `setup_expensify.yml` runs `pip uninstall mitmproxy` | Same as above |
| 4 | `run.sh` hangs, `/setup_done.txt` never created | `RUNTIME_SETUP=true` triggers 2nd playbook with nvm conflict | Skip `run.sh`, start services inline |
| 5 | Test errors invisible in output | `.slice(0, 500)` shows setup logs, not errors | `.slice(-3000)` shows tail |

## Test results

```
✅ bun test ./src — 30/30 passed
✅ bunx --bun tsc -p . --noEmit — pass
✅ v1: --agent cursor --exercise acronym — 100% (68.6s)
✅ v2: --test-only --exercise 49840_659 — PASSED (332s)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3efef2c-885b-400a-b855-94a470dee17d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3efef2c-885b-400a-b855-94a470dee17d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

