### PR TITLE
fix(v2): mount Cursor prompt file and extend SWE-Lancer test setup wait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ commit-body.md
 .yarn
 yarn.lock
 .patches/
+.cursor-agent-prompts/

--- a/src/agents/builders/cursor.ts
+++ b/src/agents/builders/cursor.ts
@@ -1,6 +1,11 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Command } from '../../execution/types';
 import type { AgentBuilder, AgentConfig, FileList } from '../types';
 import { BaseAgentBuilder } from '../base';
 import { requireEnv } from '../../utils/env';
+
+const PROMPT_MOUNT_CONTAINER = '/tmp/ts-bench-cursor-prompt.txt';
 
 export class CursorAgentBuilder extends BaseAgentBuilder implements AgentBuilder {
     constructor(agentConfig: AgentConfig) {
@@ -10,6 +15,33 @@ export class CursorAgentBuilder extends BaseAgentBuilder implements AgentBuilder
     protected getEnvironmentVariables(): Record<string, string> {
         return {
             CURSOR_API_KEY: requireEnv('CURSOR_API_KEY', 'Missing CURSOR_API_KEY for Cursor Agent')
+        };
+    }
+
+    override async buildCommand(instructions: string, fileList?: FileList): Promise<Command> {
+        const useDockerV2 =
+            this.config.dataset === 'v2' &&
+            this.config.useDocker !== false &&
+            this.config.exercise;
+
+        if (useDockerV2) {
+            const dir = join(process.cwd(), '.cursor-agent-prompts');
+            await mkdir(dir, { recursive: true });
+            const hostPath = join(dir, `${this.config.exercise}.txt`);
+            await writeFile(hostPath, instructions, 'utf8');
+
+            const args = this.getCoreArgs('$(cat ' + PROMPT_MOUNT_CONTAINER + ')', fileList);
+            return {
+                args,
+                env: this.getEnvironmentVariables(),
+                promptFileHostPath: hostPath,
+                promptFileContainerPath: PROMPT_MOUNT_CONTAINER
+            };
+        }
+
+        return {
+            args: this.getCoreArgs(instructions, fileList),
+            env: this.getEnvironmentVariables()
         };
     }
 

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -13,13 +13,20 @@ import { VibeAgentBuilder } from './builders/vibe';
 import { KimiAgentBuilder } from './builders/kimi';
 
 export class AgentFactory {
-    static create(config: BenchmarkConfig, containerName: string, agentScriptPath: string): AgentBuilder {
+    static create(
+        config: BenchmarkConfig,
+        containerName: string,
+        agentScriptPath: string,
+        exercise?: string
+    ): AgentBuilder {
         const agentConfig = {
             model: config.model,
             provider: config.provider,
             containerName,
             agentScriptPath,
-            useDocker: config.useDocker
+            useDocker: config.useDocker,
+            dataset: config.dataset,
+            exercise
         };
 
         switch (config.agent) {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,4 +1,5 @@
 import type { Command } from '../execution/types';
+import type { DatasetType } from '../config/types';
 
 export interface AgentBuilder {
     buildCommand(instructions: string, fileList?: FileList): Promise<Command>;
@@ -15,4 +16,7 @@ export interface AgentConfig {
     containerName: string;
     agentScriptPath: string;
     useDocker?: boolean;
+    dataset?: DatasetType;
+    /** Current task id (e.g. v2 issue id); used for stable temp paths */
+    exercise?: string;
 }

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -5,7 +5,7 @@ import { BenchmarkReporter } from './reporter';
 import { LeaderboardGenerator } from '../utils/leaderboard-generator';
 import { VersionDetector } from '../utils/version-detector';
 import { getAgentScriptPath } from '../config/paths';
-import { TS_BENCH_CONTAINER } from '../config/constants';
+import { SWELANCER_IMAGE, TS_BENCH_CONTAINER } from '../config/constants';
 import { sanitizeFilenameSegment } from '../utils/file-name';
 
 export class BenchmarkRunner {
@@ -32,9 +32,10 @@ export class BenchmarkRunner {
         if (!agentVersion) {
             console.log(`🔍 Detecting ${args.agent} version...`);
             const versionDetector = new VersionDetector();
+            const versionContainer = args.dataset === 'v2' ? SWELANCER_IMAGE : TS_BENCH_CONTAINER;
             agentVersion = await versionDetector.detectAgentVersion(args.agent, {
                 useDocker,
-                containerName: TS_BENCH_CONTAINER,
+                containerName: versionContainer,
                 agentScriptPath
             });
             console.log(`📦 Detected ${args.agent} version: ${agentVersion}\n`);
@@ -58,12 +59,19 @@ export class BenchmarkRunner {
             if (useDocker) {
                 // Run tests using the provided ansible playbook
                 // We need to set CI=true to avoid interactive prompts if any
-                testCommand = 'export CI=true && /app/tests/run.sh & for i in {1..120}; do [ -f /setup_done.txt ] && break; sleep 1; done; if [ ! -f /setup_done.txt ]; then echo "setup did not complete"; exit 1; fi; ansible-playbook -i "localhost," --connection=local /app/tests/run_tests.yml';
+                const setupWaitSec = parseInt(process.env.TS_BENCH_V2_SETUP_WAIT_SEC || '600', 10) || 600;
+                testCommand = `export CI=true && /app/tests/run.sh & for i in $(seq 1 ${setupWaitSec}); do [ -f /setup_done.txt ] && break; sleep 1; done; if [ ! -f /setup_done.txt ]; then echo "setup did not complete"; exit 1; fi; ansible-playbook -i "localhost," --connection=local /app/tests/run_tests.yml`;
             } else {
                 // Native V2: Run Jest on changed files
                 testCommand = `npm rebuild canvas && npm test -- -o`;
             }
         }
+
+        const requestedTimeout = args.timeout ?? 300;
+        const exerciseTimeout =
+            args.dataset === 'v2' && requestedTimeout === 300
+                ? 900
+                : requestedTimeout;
 
         const config: BenchmarkConfig = {
             testCommand,
@@ -74,7 +82,7 @@ export class BenchmarkRunner {
             useDocker,
             version: agentVersion,
             showProgress: args.showProgress,
-            timeout: args.timeout,
+            timeout: exerciseTimeout,
             outputDir: args.outputDir,
             dataset: args.dataset
         };

--- a/src/execution/docker-strategy.ts
+++ b/src/execution/docker-strategy.ts
@@ -12,6 +12,11 @@ export class DockerExecutionStrategy implements ExecutionStrategy {
       // Mount ts-bench root to /ts-bench-host so we can access scripts
       const hostMount = ['-v', `${process.cwd()}:/ts-bench-host:ro`];
 
+      const promptMount: string[] =
+        core.promptFileHostPath && core.promptFileContainerPath
+          ? ['-v', `${core.promptFileHostPath}:${core.promptFileContainerPath}:ro`]
+          : [];
+
       // Mount local .claude directory to capture logs
       const claudeMount = ['-v', `${join(process.env.HOME || '/root', '.claude')}:/root/.claude`];
 
@@ -46,9 +51,20 @@ export class DockerExecutionStrategy implements ExecutionStrategy {
 
       // Inline the core command into a single bash -c string instead of using
       // (exec "$@") which replaces the shell and kills background services.
-      const coreCommandStr = core.args.length >= 3 && core.args[0] === 'bash' && core.args[1] === '-c'
+      let coreCommandStr = core.args.length >= 3 && core.args[0] === 'bash' && core.args[1] === '-c'
         ? core.args[2]!
         : core.args.join(' ');
+
+      if (core.promptFileHostPath && core.promptFileContainerPath) {
+        const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+        const pIdx = core.args.indexOf('-p');
+        const promptPath = core.promptFileContainerPath;
+        if (pIdx !== -1 && pIdx + 1 < core.args.length) {
+          const before = core.args.slice(0, pIdx).map(sq);
+          const after = core.args.slice(pIdx + 2).map(sq);
+          coreCommandStr = [...before, '-p', `"$(cat ${promptPath})"`, ...after].join(' ');
+        }
+      }
 
       const command = [
         ...DOCKER_BASE_ARGS,
@@ -57,6 +73,7 @@ export class DockerExecutionStrategy implements ExecutionStrategy {
         ...createEnvironmentArgs(env),
         "--platform", "linux/amd64",
         ...hostMount,
+        ...promptMount,
         ...claudeMount,
         ...npmCacheMount,
         ...patchesMount,

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -1,6 +1,9 @@
 export interface Command {
   args: string[];
   env?: Record<string, string>;
+  /** When set (v2 Docker + Cursor), mount this host file and expand prompt from file instead of inline -p */
+  promptFileHostPath?: string;
+  promptFileContainerPath?: string;
 }
 
 export interface PrepareContext {

--- a/src/runners/agent.ts
+++ b/src/runners/agent.ts
@@ -35,7 +35,7 @@ export class AgentRunner {
 
         try {
             const agentScriptPath = getAgentScriptPath(useDocker, config.dataset);
-            const agentBuilder = AgentFactory.create(config, this.containerName, agentScriptPath);
+            const agentBuilder = AgentFactory.create(config, this.containerName, agentScriptPath, exercise);
             const instructions = await this.datasetReader.getInstructions(exercise, this.baseInstruction, this.customInstruction);
             const fileList = await this.datasetReader.getTaskFiles(exercise);
             const coreCommand = await agentBuilder.buildCommand(instructions, fileList);


### PR DESCRIPTION
- Write v2 instructions to .cursor-agent-prompts/<issue>.txt and pass -p via $(cat ...) in Docker so shell metacharacters in GitHub issues do not break bash -c.
- Quote agent argv when using prompt file mount to preserve command boundaries.
- Detect Cursor agent version inside swelancer image when dataset is v2.
- Wait up to 600s (TS_BENCH_V2_SETUP_WAIT_SEC) for /setup_done.txt; bump default v2 exercise timeout from 300s to 900s when --timeout not overridden.