### PR TITLE
feat: add grok build agent support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Copy this file to .env and fill in values for local execution.
 # Only the key(s) required for your chosen --agent / --provider are needed.
+# Grok Build uses XAI_API_KEY; ts-bench also forwards it as GROK_CODE_XAI_API_KEY for the Grok CLI.
 
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=

--- a/.github/workflows/benchmark-v2-set.yml
+++ b/.github/workflows/benchmark-v2-set.yml
@@ -31,6 +31,7 @@ on:
           - claude
           - codex
           - gemini
+          - grok
           - opencode
           - goose
           - qwen

--- a/.github/workflows/benchmark-v2.yml
+++ b/.github/workflows/benchmark-v2.yml
@@ -26,6 +26,7 @@ on:
           - claude
           - codex
           - gemini
+          - grok
           - opencode
           - goose
           - qwen

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,6 +12,7 @@ on:
           - claude
           - codex
           - gemini
+          - grok
           - opencode
           - goose
           - qwen
@@ -123,6 +124,10 @@ jobs:
             gemini)
               npm install -g @google/gemini-cli
               ;;
+            grok)
+              curl -fsSL https://x.ai/cli/install.sh | bash
+              echo "PATH=$HOME/.local/bin:$PATH" >> "$GITHUB_ENV"
+              ;;
             qwen)
               npm install -g @qwen-code/qwen-code
               ;;
@@ -198,6 +203,7 @@ jobs:
             aider)    cmd=aider ;;
             codex)    cmd="codex --version" ;;
             gemini)   cmd=gemini ;;
+            grok)     cmd=grok ;;
             opencode) cmd=opencode ;;
             qwen)     cmd=qwen ;;
             cursor)   cmd=cursor-agent ;;
@@ -226,6 +232,37 @@ jobs:
             echo "Agent CLI '$agent' found."
           fi
 
+      - name: Setup Grok model config
+        if: ${{ github.event.inputs.agent == 'grok' && env.USE_DOCKER == 'false' }}
+        env:
+          MODEL: ${{ github.event.inputs.model }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.grok"
+
+          cat > "$HOME/.grok/config.toml" <<EOF
+          [model."${MODEL}"]
+          model = "${MODEL}"
+          base_url = "https://api.x.ai/v1"
+          name = "${MODEL}"
+          env_key = "GROK_CODE_XAI_API_KEY"
+
+          [models]
+          default = "${MODEL}"
+          EOF
+
+      - name: List Grok models
+        if: ${{ github.event.inputs.agent == 'grok' && env.USE_DOCKER == 'false' }}
+        env:
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          GROK_CODE_XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          echo "Available Grok CLI models:"
+          grok models || {
+            echo "::warning::Unable to list Grok CLI models. Continuing with configured model."
+          }
+
       - name: Run benchmark
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -237,6 +274,7 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          GROK_CODE_XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -126,7 +126,8 @@ jobs:
               ;;
             grok)
               curl -fsSL https://x.ai/cli/install.sh | bash
-              echo "PATH=$HOME/.local/bin:$PATH" >> "$GITHUB_ENV"
+              # The x.ai installer puts the binary in ~/.grok/bin, not ~/.local/bin
+              echo "PATH=$HOME/.grok/bin:$PATH" >> "$GITHUB_ENV"
               ;;
             qwen)
               npm install -g @qwen-code/qwen-code

--- a/README.md
+++ b/README.md
@@ -18,9 +18,19 @@ ts-bench --agent claude --model <model>
 
 ```bash
 ts-bench --agent claude --model <model>
+ts-bench --agent grok --model grok-build-0.1
 ```
 
 Omit `--model` to use the agent's default model.
+
+Run Grok Build with an xAI API key:
+
+```bash
+export XAI_API_KEY="xai-..."
+ts-bench --agent grok --model grok-build-0.1
+```
+
+In GitHub Actions, ts-bench writes a Grok custom model config so the Grok CLI uses the requested xAI API model id.
 
 Frozen baseline for reproducibility: tag [`v1-final`](https://github.com/laiso/ts-bench/releases/tag/v1-final)
 

--- a/config/agents/grok.yaml
+++ b/config/agents/grok.yaml
@@ -1,0 +1,20 @@
+name: grok
+description: "xAI Grok Build CLI agent"
+defaultProvider: xai
+install:
+  method: curl
+  url: "https://x.ai/cli/install.sh"
+  bin: grok
+
+require:
+  - XAI_API_KEY
+
+env:
+  XAI_API_KEY: "${XAI_API_KEY}"
+  GROK_CODE_XAI_API_KEY: "${XAI_API_KEY}"
+
+command:
+  - grok
+  - -p
+  - "{instructions}"
+  - "{#model}-m {model}{/model}"

--- a/config/agents/grok.yaml
+++ b/config/agents/grok.yaml
@@ -18,3 +18,5 @@ command:
   - -p
   - "{instructions}"
   - "{#model}-m {model}{/model}"
+  - --permission-mode
+  - bypassPermissions

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -117,6 +117,13 @@ case "$AGENT" in
     ensure_node_cli "dsh" "@deepseek-ai/dsh"
     exec dsh "$@"
     ;;
+  grok)
+    if ! command -v "grok" >/dev/null 2>&1; then
+      echo "[run-agent] Installing Grok Build CLI" >&2
+      curl -fsSL https://x.ai/cli/install.sh | bash
+    fi
+    exec grok "$@"
+    ;;
   kimi)
     if command -v "kimi" >/dev/null 2>&1; then
       exec kimi "$@"

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -122,6 +122,8 @@ case "$AGENT" in
       echo "[run-agent] Installing Grok Build CLI" >&2
       curl -fsSL https://x.ai/cli/install.sh | bash
     fi
+    # The x.ai installer puts the binary in ~/.grok/bin, which is not on PATH
+    export PATH="${HOME}/.grok/bin:${PATH}"
     exec grok "$@"
     ;;
   kimi)

--- a/scripts/smoke-agents.sh
+++ b/scripts/smoke-agents.sh
@@ -9,6 +9,7 @@ AGENTS=(
   claude
   codex
   gemini
+  grok
   opencode
   qwen
   aider

--- a/specs/000-project-handbook/environment.md
+++ b/specs/000-project-handbook/environment.md
@@ -153,8 +153,10 @@ bun src/index.ts --agent claude --provider openrouter --model <openrouter-model-
 
 - Required env: `XAI_API_KEY`
 - Default provider for `--agent grok` is `xai`
+- `--provider` is ignored for grok: the Grok CLI always talks to `api.x.ai/v1`
 - Recommended model from xAI Build docs: `grok-build-0.1`
 - The runner uses Grok's headless prompt mode: `grok -p <prompt>`
+- The x.ai installer puts the binary in `~/.grok/bin`; `run-agent.sh` adds it to `PATH`
 - GitHub Actions writes a Grok custom model config so the Grok CLI uses the requested xAI API model id.
 
 Example:

--- a/specs/000-project-handbook/environment.md
+++ b/specs/000-project-handbook/environment.md
@@ -121,9 +121,9 @@ Implementation: `src/utils/docker.ts` (`createAuthCacheArgs`, `hasAuthCache`), a
 
 ## Main CLI Options
 
-- `--agent <agent>`: Agent to use (claude/goose/aider/codex/gemini/opencode/qwen/cursor/copilot/vibe/kimi)
+- `--agent <agent>`: Agent to use (claude/goose/aider/codex/gemini/grok/opencode/qwen/cursor/copilot/vibe/kimi/dns)
 - `--model <model>`: Model to use
-- `--provider <provider>`: openai/anthropic/google/openrouter/dashscope/xai/deepseek/moonshot
+- `--provider <provider>`: openai/anthropic/google/openrouter/dashscope/xai/deepseek/github/cerebras/mistral/moonshot/zai
 - `--docker`: Switch to Docker execution
 - **v1**: `--exercise <name|N|a,b,c>` — single slug, first N exercises, or comma-separated slugs
 - **v2**: `--task <id>`, `--tasks id,id,...`, or `--task-limit <n>` — SWE-Lancer task ids only (`--exercise` is rejected with `--dataset v2`)
@@ -145,6 +145,23 @@ Example:
 ```
 export OPENROUTER_API_KEY=sk-or-...
 bun src/index.ts --agent claude --provider openrouter --model <openrouter-model-id> --exercise acronym --docker
+```
+
+---
+
+## Grok Build (xAI)
+
+- Required env: `XAI_API_KEY`
+- Default provider for `--agent grok` is `xai`
+- Recommended model from xAI Build docs: `grok-build-0.1`
+- The runner uses Grok's headless prompt mode: `grok -p <prompt>`
+- GitHub Actions writes a Grok custom model config so the Grok CLI uses the requested xAI API model id.
+
+Example:
+
+```
+export XAI_API_KEY=xai-...
+bun src/index.ts --agent grok --model grok-build-0.1 --exercise acronym
 ```
 
 ---

--- a/specs/000-project-handbook/environment.md
+++ b/specs/000-project-handbook/environment.md
@@ -155,7 +155,7 @@ bun src/index.ts --agent claude --provider openrouter --model <openrouter-model-
 - Default provider for `--agent grok` is `xai`
 - `--provider` is ignored for grok: the Grok CLI always talks to `api.x.ai/v1`
 - Recommended model from xAI Build docs: `grok-build-0.1`
-- The runner uses Grok's headless prompt mode: `grok -p <prompt>`
+- The runner uses Grok's headless prompt mode: `grok -p <prompt> --permission-mode bypassPermissions`
 - The x.ai installer puts the binary in `~/.grok/bin`; `run-agent.sh` adds it to `PATH`
 - GitHub Actions writes a Grok custom model config so the Grok CLI uses the requested xAI API model id.
 

--- a/src/agents/__tests__/loader.test.ts
+++ b/src/agents/__tests__/loader.test.ts
@@ -48,6 +48,7 @@ describe('Agent Config Loader and Template Engine', () => {
         expect(registry.kimi).toBeDefined();
         expect(registry.qwen).toBeDefined();
         expect(registry.dns).toBeDefined();
+        expect(registry.grok).toBeDefined();
     });
 
     it('custom agent schema can be converted and executed', () => {
@@ -250,6 +251,52 @@ describe('dns (dsh headless) agent', () => {
         } finally {
             if (origKey !== undefined) process.env.DEEPSEEK_API_KEY = origKey;
             else delete process.env.DEEPSEEK_API_KEY;
+        }
+    });
+});
+
+describe('grok (Grok Build) agent', () => {
+    const config: AgentConfig = {
+        model: 'grok-build-0.1',
+        provider: 'xai',
+        containerName: 'container',
+        agentScriptPath: '/path/run-agent.sh'
+    };
+
+    it('builds the grok headless prompt command', () => {
+        const registry = loadAgentRegistryFromDir();
+        const args = registry.grok!.buildArgs(config, 'Fix the two-fer exercise');
+        expect(args).toEqual([
+            'bash',
+            '/path/run-agent.sh',
+            'grok',
+            '-p',
+            'Fix the two-fer exercise',
+            '-m',
+            'grok-build-0.1'
+        ]);
+    });
+
+    it('omits -m when no model is given', () => {
+        const registry = loadAgentRegistryFromDir();
+        const args = registry.grok!.buildArgs({ ...config, model: undefined }, 'task');
+        expect(args).toEqual(['bash', '/path/run-agent.sh', 'grok', '-p', 'task']);
+    });
+
+    it('forwards XAI_API_KEY as GROK_CODE_XAI_API_KEY and fails fast without it', () => {
+        const origKey = process.env.XAI_API_KEY;
+        try {
+            delete process.env.XAI_API_KEY;
+            const registry = loadAgentRegistryFromDir();
+            expect(() => registry.grok!.getEnv(config)).toThrow(/XAI_API_KEY/);
+
+            process.env.XAI_API_KEY = 'xai-test-key';
+            const env = registry.grok!.getEnv(config);
+            expect(env.XAI_API_KEY).toBe('xai-test-key');
+            expect(env.GROK_CODE_XAI_API_KEY).toBe('xai-test-key');
+        } finally {
+            if (origKey !== undefined) process.env.XAI_API_KEY = origKey;
+            else delete process.env.XAI_API_KEY;
         }
     });
 });

--- a/src/agents/__tests__/loader.test.ts
+++ b/src/agents/__tests__/loader.test.ts
@@ -273,14 +273,24 @@ describe('grok (Grok Build) agent', () => {
             '-p',
             'Fix the two-fer exercise',
             '-m',
-            'grok-build-0.1'
+            'grok-build-0.1',
+            '--permission-mode',
+            'bypassPermissions'
         ]);
     });
 
     it('omits -m when no model is given', () => {
         const registry = loadAgentRegistryFromDir();
         const args = registry.grok!.buildArgs({ ...config, model: undefined }, 'task');
-        expect(args).toEqual(['bash', '/path/run-agent.sh', 'grok', '-p', 'task']);
+        expect(args).toEqual([
+            'bash',
+            '/path/run-agent.sh',
+            'grok',
+            '-p',
+            'task',
+            '--permission-mode',
+            'bypassPermissions'
+        ]);
     });
 
     it('forwards XAI_API_KEY as GROK_CODE_XAI_API_KEY and fails fast without it', () => {

--- a/src/agents/__tests__/v2-prompt-file.test.ts
+++ b/src/agents/__tests__/v2-prompt-file.test.ts
@@ -41,6 +41,7 @@ describe('v2 Docker: all agents use mounted prompt file', () => {
             env: [['OPENAI_API_KEY', 'x']]
         },
         { name: 'gemini', builder: new GenericAgentBuilder(baseV2, AGENT_REGISTRY.gemini!), env: [['GEMINI_API_KEY', 'x']] },
+        { name: 'grok', builder: new GenericAgentBuilder(baseV2, AGENT_REGISTRY.grok!), env: [['XAI_API_KEY', 'x']] },
         { name: 'goose', builder: new GenericAgentBuilder({ ...baseV2, provider: 'anthropic' }, AGENT_REGISTRY.goose!), env: [['ANTHROPIC_API_KEY', 'x']] },
         { name: 'opencode', builder: new GenericAgentBuilder({ ...baseV2, provider: 'openai' }, AGENT_REGISTRY.opencode!), env: [['OPENAI_API_KEY', 'x']] },
         {

--- a/src/agents/builders/__tests__/registry.test.ts
+++ b/src/agents/builders/__tests__/registry.test.ts
@@ -44,7 +44,7 @@ function restoreEnvKeys(originals: Record<string, string | undefined>): void {
 
 describe('AGENT_REGISTRY', () => {
     it('has entries for all known agents', () => {
-        const agents: AgentType[] = ['claude', 'goose', 'aider', 'codex', 'copilot', 'gemini', 'opencode', 'qwen', 'cursor', 'vibe', 'kimi', 'dns'];
+        const agents: AgentType[] = ['claude', 'goose', 'aider', 'codex', 'copilot', 'gemini', 'grok', 'opencode', 'qwen', 'cursor', 'vibe', 'kimi', 'dns'];
         for (const agent of agents) {
             expect(AGENT_REGISTRY[agent]).toBeDefined();
         }
@@ -81,6 +81,40 @@ describe('GenericAgentBuilder via registry', () => {
         } finally {
             if (origKey === undefined) delete process.env.GEMINI_API_KEY;
             else process.env.GEMINI_API_KEY = origKey;
+        }
+    });
+
+    it('grok: uses XAI_API_KEY and headless prompt mode', async () => {
+        const origKey = process.env.XAI_API_KEY;
+        process.env.XAI_API_KEY = 'test-xai-key';
+        try {
+            const builder = new GenericAgentBuilder(BASE_CONFIG, AGENT_REGISTRY.grok!);
+            const command = await builder.buildCommand('instructions');
+            expect(command.args.slice(0, 3)).toEqual(['bash', SCRIPT_PATH, 'grok']);
+            expect(command.args).toContain('-p');
+            expect(command.args).toContain('-m');
+            expect(command.env?.XAI_API_KEY).toBe('test-xai-key');
+            expect(command.env?.GROK_CODE_XAI_API_KEY).toBe('test-xai-key');
+        } finally {
+            if (origKey === undefined) delete process.env.XAI_API_KEY;
+            else process.env.XAI_API_KEY = origKey;
+        }
+    });
+
+    it('grok: passes the requested model id through to Grok CLI', async () => {
+        const origKey = process.env.XAI_API_KEY;
+        process.env.XAI_API_KEY = 'test-xai-key';
+        try {
+            const builder = new GenericAgentBuilder(
+                { ...BASE_CONFIG, model: 'grok-build-0.1' },
+                AGENT_REGISTRY.grok!
+            );
+            const command = await builder.buildCommand('instructions');
+            expect(command.args).toContain('-m');
+            expect(command.args[command.args.indexOf('-m') + 1]).toBe('grok-build-0.1');
+        } finally {
+            if (origKey === undefined) delete process.env.XAI_API_KEY;
+            else process.env.XAI_API_KEY = origKey;
         }
     });
 

--- a/src/site/shared/__tests__/format.test.ts
+++ b/src/site/shared/__tests__/format.test.ts
@@ -8,6 +8,7 @@ describe('agentDisplayName', () => {
         expect(agentDisplayName('goose')).toBe('Goose CLI');
         expect(agentDisplayName('aider')).toBe('Aider');
         expect(agentDisplayName('gemini')).toBe('Gemini CLI');
+        expect(agentDisplayName('grok')).toBe('Grok Build');
         expect(agentDisplayName('qwen')).toBe('Qwen Code');
         expect(agentDisplayName('cursor')).toBe('Cursor Agent');
         expect(agentDisplayName('copilot')).toBe('GitHub Copilot CLI');

--- a/src/site/shared/format.ts
+++ b/src/site/shared/format.ts
@@ -20,6 +20,7 @@ export function agentDisplayName(slug: string): string {
         case 'goose': return 'Goose CLI';
         case 'aider': return 'Aider';
         case 'gemini': return 'Gemini CLI';
+        case 'grok': return 'Grok Build';
         case 'qwen': return 'Qwen Code';
         case 'cursor': return 'Cursor Agent';
         case 'copilot': return 'GitHub Copilot CLI';

--- a/src/utils/__tests__/version-detector.test.ts
+++ b/src/utils/__tests__/version-detector.test.ts
@@ -75,6 +75,11 @@ describe('VersionDetector', () => {
             const detector = makeDetector({ exitCode: 0, stdout: '0.1.0-rc.6', stderr: '' });
             expect(await detector.detectAgentVersion('dns')).toBe('0.1.0-rc.6');
         });
+
+        it('parses grok version from stdout', async () => {
+            const detector = makeDetector({ exitCode: 0, stdout: 'grok 0.1.0', stderr: '' });
+            expect(await detector.detectAgentVersion('grok')).toBe('0.1.0');
+        });
     });
 
     describe('detectAgentVersion – stderr fallback', () => {

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -13,7 +13,7 @@ Basic Options:
   --agent <agent>        Agent to use (${Object.keys(AGENT_REGISTRY).join(', ')}) [default: claude]
   --dataset <v1|v2>      Dataset to use (v1: Exercism, v2: SWE-Lancer) [default: v1]
   --model <model>        Model to use (omit to use the agent's default model)
-  --provider <provider>  Provider (openai, anthropic, google, openrouter, dashscope, xai, deepseek, github, moonshot) [default: agent-specific; see AGENT_DEFAULT_PROVIDER]
+  --provider <provider>  Provider (openai, anthropic, google, openrouter, dashscope, xai, deepseek, github, cerebras, mistral, moonshot, zai) [default: agent-specific; see AGENT_DEFAULT_PROVIDER]
   --version <version>    Agent version (e.g. 1.2.3) [default: agent-specific default]
   --agent-config <path>  Load a custom agent definition (YAML/JSON) and register it
   --agent-version <ver>  Pin the agent CLI tool version to install (mise-managed agents)
@@ -71,6 +71,7 @@ Examples:
   ts-bench --agent claude --model sonnet --save-result
   ts-bench --agent goose --model gemini --save-result
   ts-bench --agent kimi --provider moonshot --model kimi-k2.5 --save-result
+  ts-bench --agent grok --model grok-build-0.1 --save-result
   bun src/index.ts --print-instructions --   acronym      # v1: show instructions for one exercise
   bun src/index.ts --setup-auth claude                    # authenticate Claude inside Docker
 

--- a/src/utils/version-detector.ts
+++ b/src/utils/version-detector.ts
@@ -107,6 +107,8 @@ export class VersionDetector {
                 return ['kimi', '--version'];
             case 'dns':
                 return ['dsh', '--version'];
+            case 'grok':
+                return ['grok', '--version'];
             default:
                 throw new Error(`Unknown agent: ${agent}`);
         }
@@ -166,6 +168,10 @@ export class VersionDetector {
             case 'dns':
                 // dsh --version prints the bare package version, e.g. "0.1.0-rc.6"
                 return cleanOutput.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0] ?? this.extractGenericVersion(cleanOutput);
+            case 'grok':
+                // Grok output: "grok 0.1.0" or "0.1.0"
+                const grokMatch = cleanOutput.match(/(?:grok\s+)?(\d+\.\d+\.\d+)/i);
+                return grokMatch && grokMatch[1] ? grokMatch[1] : this.extractGenericVersion(cleanOutput);
             
             default:
                 return this.extractGenericVersion(cleanOutput);


### PR DESCRIPTION
## Summary

Adds the `grok` agent — xAI's Grok Build CLI — as a declarative config on
top of the config-driven agent registry (#123). This reworks the original
implementation (which targeted the pre-#123 hardcoded registry) into the
current YAML-based system.

## Changes

1. **`config/agents/grok.yaml`** — the agent definition:
   - `defaultProvider: xai`
   - curl install of the Grok Build CLI (`https://x.ai/cli/install.sh`)
   - `require: XAI_API_KEY` (fail fast before the run), forwarded as both
     `XAI_API_KEY` and `GROK_CODE_XAI_API_KEY`
   - command `grok -p "{instructions}" --permission-mode bypassPermissions`,
     with `-m {model}` when `--model` is given

2. **`scripts/run-agent.sh`** — `grok` branch installs the CLI on demand and
   adds `~/.grok/bin` to `PATH` (the x.ai installer puts the binary there,
   not `~/.local/bin`), then `exec grok`.

3. **`src/utils/version-detector.ts`** — detect the version via `grok --version`.

4. **CI** — the v1 and v2 benchmark workflows accept `grok`:
   - agent choice list, install step (with the correct `~/.grok/bin` PATH),
     availability check
   - a "Setup Grok model config" step that writes `~/.grok/config.toml`
     (`[model."<id>"]` with `base_url = api.x.ai/v1` and
     `env_key = GROK_CODE_XAI_API_KEY`)
   - `GROK_CODE_XAI_API_KEY` forwarded to the benchmark run

5. **Docs** — README, `specs/000-project-handbook/environment.md`,
   `.env.example`, and CLI help updated for grok.

6. **Tests** — loader/registry/version-detector/format/v2-prompt-file coverage:
   command shape (`-p`, `-m`, permission mode), model passthrough, env
   forwarding, and fail-fast on a missing key.

## Verification (real GHA run)

`grok` solved the `accumulate` exercise end-to-end on GitHub Actions
(`--agent grok --provider xai --model grok-build-0.1 --exercise 1`):

```
🤖 accumulate - Agent Success (55.7s)
🧪 accumulate - Test Success (9.2s)
✅ accumulate - Overall Success (65.0s)
🎯 Success Rate: 100.0% (1/1)
```

Notes from debugging the smoke run against the real CLI (v1.0.3):
- `--permission-mode bypassPermissions` is required: `-p` single-turn mode
  refuses tool execution under the default permission mode, so the agent
  could not edit files.
- The `~/.grok/config.toml` `env_key`/`base_url` mechanism is honored by the
  CLI (auth reaches `api.x.ai`).
- `grok-build-0.1` is a valid model id (shown as default by `grok models`).

## Other

- `bun test ./src`: 207 passing (7 new tests for grok).
- `bun run typecheck`: identical to `main` (9 pre-existing errors, no new ones).
