### PR TITLE
feat: add dns agent (dsh headless)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Setup Node (for corepack/yarn)
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # dsh (the dns agent CLI) requires Node >= 22.18 (Promise.withResolvers,
+          # node:module.stripTypeScriptTypes); 20 is no longer sufficient.
+          node-version: "24"
 
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,7 @@ on:
           - copilot
           - vibe
           - kimi
+          - dns
       provider:
         description: Provider (openai, anthropic, google, openrouter, etc.)
         required: true
@@ -140,6 +141,9 @@ jobs:
               curl -LsSf https://code.kimi.com/install.sh | bash
               echo "PATH=$HOME/.local/bin:$PATH" >> "$GITHUB_ENV"
               ;;
+            dns)
+              npm install -g @deepseek-ai/dsh
+              ;;
             *)
               echo "No installer defined for agent: $agent" >&2
               ;;
@@ -198,6 +202,7 @@ jobs:
             copilot)  cmd="copilot --version" ;;
             vibe)     cmd=vibe ;;
             kimi)     cmd="kimi --version" ;;
+            dns)      cmd=dsh ;;
             *)        cmd="" ;;
           esac
 

--- a/config/agents/dns.yaml
+++ b/config/agents/dns.yaml
@@ -1,0 +1,19 @@
+name: dns
+description: "DeepSeek Harness headless agent (dsh) — one-shot task runner"
+defaultProvider: deepseek
+install:
+  method: npm
+  package: "@deepseek-ai/dsh"
+  bin: dsh
+
+require:
+  - DEEPSEEK_API_KEY
+
+env:
+  DEEPSEEK_API_KEY: "${DEEPSEEK_API_KEY}"
+
+command:
+  - dsh
+  - --profile
+  - headless
+  - "{instructions}"

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -113,6 +113,10 @@ case "$AGENT" in
     ensure_node_cli "copilot" "@github/copilot"
     exec copilot "$@"
     ;;
+  dsh | dns)
+    ensure_node_cli "dsh" "@deepseek-ai/dsh"
+    exec dsh "$@"
+    ;;
   kimi)
     if command -v "kimi" >/dev/null 2>&1; then
       exec kimi "$@"

--- a/src/agents/__tests__/loader.test.ts
+++ b/src/agents/__tests__/loader.test.ts
@@ -47,6 +47,7 @@ describe('Agent Config Loader and Template Engine', () => {
         expect(registry.vibe).toBeDefined();
         expect(registry.kimi).toBeDefined();
         expect(registry.qwen).toBeDefined();
+        expect(registry.dns).toBeDefined();
     });
 
     it('custom agent schema can be converted and executed', () => {
@@ -213,5 +214,42 @@ describe('Kimi --config generation', () => {
         expect(parsed.models['kimi-k2'].max_context_size).toBe(262144);
         expect(args).toContain('--model');
         expect(args).toContain('kimi-k2');
+    });
+});
+
+describe('dns (dsh headless) agent', () => {
+    const config: AgentConfig = {
+        model: undefined,
+        provider: 'deepseek',
+        containerName: 'container',
+        agentScriptPath: '/path/run-agent.sh'
+    };
+
+    it('builds the dsh headless command with the task as the positional argument', () => {
+        const registry = loadAgentRegistryFromDir();
+        const args = registry.dns!.buildArgs(config, 'Fix the two-fer exercise');
+        expect(args).toEqual([
+            'bash',
+            '/path/run-agent.sh',
+            'dsh',
+            '--profile',
+            'headless',
+            'Fix the two-fer exercise'
+        ]);
+    });
+
+    it('forwards DEEPSEEK_API_KEY and fails fast without it', () => {
+        const origKey = process.env.DEEPSEEK_API_KEY;
+        try {
+            delete process.env.DEEPSEEK_API_KEY;
+            const registry = loadAgentRegistryFromDir();
+            expect(() => registry.dns!.getEnv(config)).toThrow(/DEEPSEEK_API_KEY/);
+
+            process.env.DEEPSEEK_API_KEY = 'sk-test-key';
+            expect(registry.dns!.getEnv(config).DEEPSEEK_API_KEY).toBe('sk-test-key');
+        } finally {
+            if (origKey !== undefined) process.env.DEEPSEEK_API_KEY = origKey;
+            else delete process.env.DEEPSEEK_API_KEY;
+        }
     });
 });

--- a/src/agents/builders/__tests__/registry.test.ts
+++ b/src/agents/builders/__tests__/registry.test.ts
@@ -44,7 +44,7 @@ function restoreEnvKeys(originals: Record<string, string | undefined>): void {
 
 describe('AGENT_REGISTRY', () => {
     it('has entries for all known agents', () => {
-        const agents: AgentType[] = ['claude', 'goose', 'aider', 'codex', 'copilot', 'gemini', 'opencode', 'qwen', 'cursor', 'vibe', 'kimi'];
+        const agents: AgentType[] = ['claude', 'goose', 'aider', 'codex', 'copilot', 'gemini', 'opencode', 'qwen', 'cursor', 'vibe', 'kimi', 'dns'];
         for (const agent of agents) {
             expect(AGENT_REGISTRY[agent]).toBeDefined();
         }

--- a/src/utils/__tests__/version-detector.test.ts
+++ b/src/utils/__tests__/version-detector.test.ts
@@ -70,6 +70,11 @@ describe('VersionDetector', () => {
             const detector = makeDetector({ exitCode: 0, stdout: '1.0.0', stderr: '' });
             expect(await detector.detectAgentVersion('kimi')).toBe('1.0.0');
         });
+
+        it('parses dsh version from stdout', async () => {
+            const detector = makeDetector({ exitCode: 0, stdout: '0.1.0-rc.6', stderr: '' });
+            expect(await detector.detectAgentVersion('dns')).toBe('0.1.0-rc.6');
+        });
     });
 
     describe('detectAgentVersion – stderr fallback', () => {

--- a/src/utils/version-detector.ts
+++ b/src/utils/version-detector.ts
@@ -105,6 +105,8 @@ export class VersionDetector {
                 return ['vibe', '--help'];
             case 'kimi':
                 return ['kimi', '--version'];
+            case 'dns':
+                return ['dsh', '--version'];
             default:
                 throw new Error(`Unknown agent: ${agent}`);
         }
@@ -161,6 +163,9 @@ export class VersionDetector {
                 return this.extractGenericVersion(cleanOutput);
             case 'kimi':
                 return this.extractGenericVersion(cleanOutput);
+            case 'dns':
+                // dsh --version prints the bare package version, e.g. "0.1.0-rc.6"
+                return cleanOutput.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0] ?? this.extractGenericVersion(cleanOutput);
             
             default:
                 return this.extractGenericVersion(cleanOutput);


### PR DESCRIPTION
## Summary

Adds the `dns` agent — a declarative config that runs the DeepSeek Harness
headless CLI (`dsh`) as a one-shot benchmark target. This is the same entry
point used to drive the coding agent interactively: `dsh --profile headless "<task>"`.

## Changes

1. **`config/agents/dns.yaml`** — the agent definition:
   - `defaultProvider: deepseek`
   - npm install of `@deepseek-ai/dsh` (bin: `dsh`)
   - `require: DEEPSEEK_API_KEY` (fail fast before the run)
   - command `dsh --profile headless "{instructions}"`

2. **`scripts/run-agent.sh`** — new `dsh | dns` branch that installs the CLI
   on demand via `ensure_node_cli` (same path as opencode/codex/claude) and
   then `exec dsh`.

3. **`src/utils/version-detector.ts`** — detect the version via
   `dsh --version` (preserving the prerelease suffix, e.g. `0.1.0-rc.6`).

## Notes

- `dsh` self-bootstraps its `headless` profile on first run and resolves the
  `dsh-base`/`dsh-headless` bundles from its own install, so no extra setup
  (pnpm/network) is required beyond `npm install -g @deepseek-ai/dsh`.
- `--model`/`--provider` are not forwarded: the headless CLI exposes a single
  task positional and selects its own default model, so `defaultProvider`
  only feeds ts-bench's environment resolution.
- Tools mode is intentionally left at the schema default (`native`), which
  ships the bash/fs/str-replace-editor tool set the benchmark needs.

## Verification

- `bun test ./src`: 200 passing (2 new tests cover the command shape, env
  forwarding, and fail-fast on a missing key; 1 covers version detection).
- `bun run typecheck`: no new errors (the 9 remaining are pre-existing on
  main).
