### PR TITLE
feat: add agy agent (Google Antigravity CLI)

### DIFF
--- a/.github/workflows/benchmark-v2-set.yml
+++ b/.github/workflows/benchmark-v2-set.yml
@@ -32,6 +32,7 @@ on:
           - codex
           - gemini
           - grok
+          - agy
           - opencode
           - goose
           - qwen

--- a/.github/workflows/benchmark-v2.yml
+++ b/.github/workflows/benchmark-v2.yml
@@ -27,6 +27,7 @@ on:
           - codex
           - gemini
           - grok
+          - agy
           - opencode
           - goose
           - qwen

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ on:
           - codex
           - gemini
           - grok
+          - agy
           - opencode
           - goose
           - qwen
@@ -129,6 +130,11 @@ jobs:
               # The x.ai installer puts the binary in ~/.grok/bin, not ~/.local/bin
               echo "PATH=$HOME/.grok/bin:$PATH" >> "$GITHUB_ENV"
               ;;
+            agy)
+              curl -fsSL https://antigravity.google/cli/install.sh | bash
+              # The Antigravity installer puts the binary in ~/.local/bin
+              echo "PATH=$HOME/.local/bin:$PATH" >> "$GITHUB_ENV"
+              ;;
             qwen)
               npm install -g @qwen-code/qwen-code
               ;;
@@ -205,6 +211,7 @@ jobs:
             codex)    cmd="codex --version" ;;
             gemini)   cmd=gemini ;;
             grok)     cmd=grok ;;
+            agy)      cmd=agy ;;
             opencode) cmd=opencode ;;
             qwen)     cmd=qwen ;;
             cursor)   cmd=cursor-agent ;;

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ ts-bench --agent grok --model grok-build-0.1
 
 In GitHub Actions, ts-bench writes a Grok custom model config so the Grok CLI uses the requested xAI API model id.
 
+Run Antigravity (agy) with a Gemini API key:
+
+```bash
+export GEMINI_API_KEY="AIza..."
+ts-bench --agent agy
+```
+
+agy runs in print mode; `run-agent.sh` enables the direct Gemini backend
+(`settings.json` `modelProvider: "gemini"`) when `GEMINI_API_KEY` is set.
+
 Frozen baseline for reproducibility: tag [`v1-final`](https://github.com/laiso/ts-bench/releases/tag/v1-final)
 
 ### v2 — SWE-Lancer

--- a/config/agents/agy.yaml
+++ b/config/agents/agy.yaml
@@ -8,9 +8,12 @@ install:
 
 # API-key mode (GEMINI_API_KEY + settings.json modelProvider "gemini") is
 # enabled by run-agent.sh; without a key the CLI falls back to its cached
-# Google Sign-In (OAuth) login.
+# Google Sign-In (OAuth) login. The model is forwarded as AGY_MODEL because
+# agy's model ids contain spaces ("Gemini 3.1 Pro") that the arg template
+# cannot pass; run-agent.sh writes it into settings.json.
 env:
   GEMINI_API_KEY: "${GEMINI_API_KEY}"
+  AGY_MODEL: "{model}"
 
 command:
   - agy

--- a/config/agents/agy.yaml
+++ b/config/agents/agy.yaml
@@ -1,0 +1,21 @@
+name: agy
+description: "Google Antigravity CLI (agy)"
+defaultProvider: google
+install:
+  method: curl
+  url: "https://antigravity.google/cli/install.sh"
+  bin: agy
+
+# API-key mode (GEMINI_API_KEY + settings.json modelProvider "gemini") is
+# enabled by run-agent.sh; without a key the CLI falls back to its cached
+# Google Sign-In (OAuth) login.
+env:
+  GEMINI_API_KEY: "${GEMINI_API_KEY}"
+
+command:
+  - agy
+  - --print
+  - "{instructions}"
+  - --dangerously-skip-permissions
+  # Note: no {#model} passthrough — agy's model ids are display names with
+  # spaces (e.g. "Gemini 3.1 Pro"), which the arg template would split.

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -126,6 +126,21 @@ case "$AGENT" in
     export PATH="${HOME}/.grok/bin:${PATH}"
     exec grok "$@"
     ;;
+  agy)
+    if ! command -v "agy" >/dev/null 2>&1; then
+      echo "[run-agent] Installing Antigravity CLI (agy)" >&2
+      curl -fsSL https://antigravity.google/cli/install.sh | bash
+    fi
+    # API-key mode: when a GEMINI_API_KEY is provided and the user has not
+    # configured their own settings, enable the direct Gemini backend
+    # (settings.json modelProvider "gemini"). Without a key, the CLI uses the
+    # cached Google Sign-In (OAuth) login instead.
+    if [ -n "${GEMINI_API_KEY:-}" ] && [ ! -f "${HOME}/.gemini/antigravity-cli/settings.json" ]; then
+      mkdir -p "${HOME}/.gemini/antigravity-cli"
+      printf '{"modelProvider": "gemini"}\n' > "${HOME}/.gemini/antigravity-cli/settings.json"
+    fi
+    exec agy "$@"
+    ;;
   kimi)
     if command -v "kimi" >/dev/null 2>&1; then
       exec kimi "$@"

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -142,7 +142,7 @@ case "$AGENT" in
       if [ -n "${AGY_MODEL:-}" ]; then
         printf '{"modelProvider": "gemini", "model": "%s"}\n' "${AGY_MODEL}" > "${HOME}/.gemini/antigravity-cli/settings.json"
       else
-        printf '{"modelProvider": "gemini", "model": "Gemini 3.1 Pro"}\n' > "${HOME}/.gemini/antigravity-cli/settings.json"
+        printf '{"modelProvider": "gemini", "model": "Gemini 3.7 Flash (High)"}\n' > "${HOME}/.gemini/antigravity-cli/settings.json"
       fi
     fi
     exec agy "$@"

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -134,10 +134,16 @@ case "$AGENT" in
     # API-key mode: when a GEMINI_API_KEY is provided and the user has not
     # configured their own settings, enable the direct Gemini backend
     # (settings.json modelProvider "gemini"). Without a key, the CLI uses the
-    # cached Google Sign-In (OAuth) login instead.
+    # cached Google Sign-In (OAuth) login instead. The model comes from the
+    # AGY_MODEL env (ts-bench --model); agy's default model resolution falls
+    # back to a non-agentic model, so a stable default is written when unset.
     if [ -n "${GEMINI_API_KEY:-}" ] && [ ! -f "${HOME}/.gemini/antigravity-cli/settings.json" ]; then
       mkdir -p "${HOME}/.gemini/antigravity-cli"
-      printf '{"modelProvider": "gemini"}\n' > "${HOME}/.gemini/antigravity-cli/settings.json"
+      if [ -n "${AGY_MODEL:-}" ]; then
+        printf '{"modelProvider": "gemini", "model": "%s"}\n' "${AGY_MODEL}" > "${HOME}/.gemini/antigravity-cli/settings.json"
+      else
+        printf '{"modelProvider": "gemini", "model": "Gemini 3.1 Pro"}\n' > "${HOME}/.gemini/antigravity-cli/settings.json"
+      fi
     fi
     exec agy "$@"
     ;;

--- a/scripts/smoke-agents.sh
+++ b/scripts/smoke-agents.sh
@@ -10,6 +10,7 @@ AGENTS=(
   codex
   gemini
   grok
+  agy
   opencode
   qwen
   aider

--- a/specs/000-project-handbook/environment.md
+++ b/specs/000-project-handbook/environment.md
@@ -121,7 +121,7 @@ Implementation: `src/utils/docker.ts` (`createAuthCacheArgs`, `hasAuthCache`), a
 
 ## Main CLI Options
 
-- `--agent <agent>`: Agent to use (claude/goose/aider/codex/gemini/grok/opencode/qwen/cursor/copilot/vibe/kimi/dns)
+- `--agent <agent>`: Agent to use (claude/goose/aider/codex/gemini/grok/agy/opencode/qwen/cursor/copilot/vibe/kimi/dns)
 - `--model <model>`: Model to use
 - `--provider <provider>`: openai/anthropic/google/openrouter/dashscope/xai/deepseek/github/cerebras/mistral/moonshot/zai
 - `--docker`: Switch to Docker execution
@@ -164,6 +164,38 @@ Example:
 ```
 export XAI_API_KEY=xai-...
 bun src/index.ts --agent grok --model grok-build-0.1 --exercise acronym
+```
+
+---
+
+## Antigravity CLI (agy)
+
+Two authentication modes:
+
+- **API key (recommended for CI)**: export `GEMINI_API_KEY`. `run-agent.sh`
+  then writes `~/.gemini/antigravity-cli/settings.json` with
+  `{"modelProvider": "gemini"}` (only when the file does not already exist) so
+  the CLI talks to the Gemini API directly, no sign-in needed.
+- **Google Sign-In (OAuth)**: run `agy` once interactively and complete the
+  browser flow; credentials are cached locally for later headless runs.
+
+The runner uses print mode: `agy --print <prompt> --dangerously-skip-permissions`.
+
+Notes:
+
+- The Antigravity installer puts the binary in `~/.local/bin` (already on the
+  `run-agent.sh` PATH).
+- `--model` is not passed through: agy's model ids are display names with
+  spaces (e.g. `"Gemini 3.1 Pro"`), which the arg template cannot preserve;
+  the CLI uses its default model.
+- CI environments can use the API-key mode (the v1/v2 workflows forward
+  `GEMINI_API_KEY`); the OAuth flow itself cannot run headless.
+
+Example:
+
+```
+export GEMINI_API_KEY=AIza...
+bun src/index.ts --agent agy --exercise acronym
 ```
 
 ---

--- a/specs/000-project-handbook/environment.md
+++ b/specs/000-project-handbook/environment.md
@@ -174,8 +174,11 @@ Two authentication modes:
 
 - **API key (recommended for CI)**: export `GEMINI_API_KEY`. `run-agent.sh`
   then writes `~/.gemini/antigravity-cli/settings.json` with
-  `{"modelProvider": "gemini"}` (only when the file does not already exist) so
-  the CLI talks to the Gemini API directly, no sign-in needed.
+  `{"modelProvider": "gemini", "model": ...}` (only when the file does not
+  already exist) so the CLI talks to the Gemini API directly, no sign-in
+  needed. `--model` is forwarded via the `AGY_MODEL` env and written into
+  `settings.json`; when omitted, `"Gemini 3.1 Pro"` is used (agy's own
+  default resolution falls back to a non-agentic model).
 - **Google Sign-In (OAuth)**: run `agy` once interactively and complete the
   browser flow; credentials are cached locally for later headless runs.
 
@@ -185,9 +188,9 @@ Notes:
 
 - The Antigravity installer puts the binary in `~/.local/bin` (already on the
   `run-agent.sh` PATH).
-- `--model` is not passed through: agy's model ids are display names with
-  spaces (e.g. `"Gemini 3.1 Pro"`), which the arg template cannot preserve;
-  the CLI uses its default model.
+- agy's model ids are display names with spaces (e.g. `"Gemini 3.1 Pro"`),
+  which the argument template cannot pass; use `--model "Gemini 3.1 Pro"` and
+  it is written into `settings.json` via `AGY_MODEL`.
 - CI environments can use the API-key mode (the v1/v2 workflows forward
   `GEMINI_API_KEY`); the OAuth flow itself cannot run headless.
 

--- a/specs/000-project-handbook/environment.md
+++ b/specs/000-project-handbook/environment.md
@@ -177,8 +177,8 @@ Two authentication modes:
   `{"modelProvider": "gemini", "model": ...}` (only when the file does not
   already exist) so the CLI talks to the Gemini API directly, no sign-in
   needed. `--model` is forwarded via the `AGY_MODEL` env and written into
-  `settings.json`; when omitted, `"Gemini 3.1 Pro"` is used (agy's own
-  default resolution falls back to a non-agentic model).
+  `settings.json`; when omitted, `"Gemini 3.7 Flash (High)"` is used (agy's
+  own default resolution falls back to a non-agentic model).
 - **Google Sign-In (OAuth)**: run `agy` once interactively and complete the
   browser flow; credentials are cached locally for later headless runs.
 
@@ -188,8 +188,8 @@ Notes:
 
 - The Antigravity installer puts the binary in `~/.local/bin` (already on the
   `run-agent.sh` PATH).
-- agy's model ids are display names with spaces (e.g. `"Gemini 3.1 Pro"`),
-  which the argument template cannot pass; use `--model "Gemini 3.1 Pro"` and
+- agy's model ids are display names with spaces (e.g. `"Gemini 3.7 Flash (High)"`),
+  which the argument template cannot pass; use `--model "Gemini 3.7 Flash (High)"` and
   it is written into `settings.json` via `AGY_MODEL`.
 - CI environments can use the API-key mode (the v1/v2 workflows forward
   `GEMINI_API_KEY`); the OAuth flow itself cannot run headless.

--- a/src/agents/__tests__/loader.test.ts
+++ b/src/agents/__tests__/loader.test.ts
@@ -333,15 +333,17 @@ describe('agy (Antigravity CLI) agent', () => {
         ]);
     });
 
-    it('forwards GEMINI_API_KEY when set and requires nothing when absent', () => {
+    it('forwards GEMINI_API_KEY and the model as AGY_MODEL', () => {
         const origKey = process.env.GEMINI_API_KEY;
         try {
             delete process.env.GEMINI_API_KEY;
             const registry = loadAgentRegistryFromDir();
-            expect(registry.agy!.getEnv(config)).toEqual({});
+            expect(registry.agy!.getEnv({ ...config, model: undefined })).toEqual({});
 
             process.env.GEMINI_API_KEY = 'ai-test-key';
-            expect(registry.agy!.getEnv(config).GEMINI_API_KEY).toBe('ai-test-key');
+            const env = registry.agy!.getEnv(config);
+            expect(env.GEMINI_API_KEY).toBe('ai-test-key');
+            expect(env.AGY_MODEL).toBe('gemini-2.5-pro');
         } finally {
             if (origKey !== undefined) process.env.GEMINI_API_KEY = origKey;
             else delete process.env.GEMINI_API_KEY;

--- a/src/agents/__tests__/loader.test.ts
+++ b/src/agents/__tests__/loader.test.ts
@@ -49,6 +49,7 @@ describe('Agent Config Loader and Template Engine', () => {
         expect(registry.qwen).toBeDefined();
         expect(registry.dns).toBeDefined();
         expect(registry.grok).toBeDefined();
+        expect(registry.agy).toBeDefined();
     });
 
     it('custom agent schema can be converted and executed', () => {
@@ -307,6 +308,43 @@ describe('grok (Grok Build) agent', () => {
         } finally {
             if (origKey !== undefined) process.env.XAI_API_KEY = origKey;
             else delete process.env.XAI_API_KEY;
+        }
+    });
+});
+
+describe('agy (Antigravity CLI) agent', () => {
+    const config: AgentConfig = {
+        model: 'gemini-2.5-pro',
+        provider: 'google',
+        containerName: 'container',
+        agentScriptPath: '/path/run-agent.sh'
+    };
+
+    it('builds the agy print command (model flag is not passed through)', () => {
+        const registry = loadAgentRegistryFromDir();
+        const args = registry.agy!.buildArgs(config, 'Fix the two-fer exercise');
+        expect(args).toEqual([
+            'bash',
+            '/path/run-agent.sh',
+            'agy',
+            '--print',
+            'Fix the two-fer exercise',
+            '--dangerously-skip-permissions'
+        ]);
+    });
+
+    it('forwards GEMINI_API_KEY when set and requires nothing when absent', () => {
+        const origKey = process.env.GEMINI_API_KEY;
+        try {
+            delete process.env.GEMINI_API_KEY;
+            const registry = loadAgentRegistryFromDir();
+            expect(registry.agy!.getEnv(config)).toEqual({});
+
+            process.env.GEMINI_API_KEY = 'ai-test-key';
+            expect(registry.agy!.getEnv(config).GEMINI_API_KEY).toBe('ai-test-key');
+        } finally {
+            if (origKey !== undefined) process.env.GEMINI_API_KEY = origKey;
+            else delete process.env.GEMINI_API_KEY;
         }
     });
 });

--- a/src/agents/__tests__/v2-prompt-file.test.ts
+++ b/src/agents/__tests__/v2-prompt-file.test.ts
@@ -42,6 +42,7 @@ describe('v2 Docker: all agents use mounted prompt file', () => {
         },
         { name: 'gemini', builder: new GenericAgentBuilder(baseV2, AGENT_REGISTRY.gemini!), env: [['GEMINI_API_KEY', 'x']] },
         { name: 'grok', builder: new GenericAgentBuilder(baseV2, AGENT_REGISTRY.grok!), env: [['XAI_API_KEY', 'x']] },
+        { name: 'agy', builder: new GenericAgentBuilder(baseV2, AGENT_REGISTRY.agy!), env: [] },
         { name: 'goose', builder: new GenericAgentBuilder({ ...baseV2, provider: 'anthropic' }, AGENT_REGISTRY.goose!), env: [['ANTHROPIC_API_KEY', 'x']] },
         { name: 'opencode', builder: new GenericAgentBuilder({ ...baseV2, provider: 'openai' }, AGENT_REGISTRY.opencode!), env: [['OPENAI_API_KEY', 'x']] },
         {

--- a/src/agents/builders/__tests__/registry.test.ts
+++ b/src/agents/builders/__tests__/registry.test.ts
@@ -94,7 +94,7 @@ describe('GenericAgentBuilder via registry', () => {
             expect(command.args).toContain('--print');
             expect(command.args).toContain('--dangerously-skip-permissions');
             expect(command.args).not.toContain('--model');
-            expect(command.env).toEqual({});
+            expect(command.env).toEqual({ AGY_MODEL: 'test-model' });
         } finally {
             if (origKey === undefined) delete process.env.GEMINI_API_KEY;
             else process.env.GEMINI_API_KEY = origKey;

--- a/src/agents/builders/__tests__/registry.test.ts
+++ b/src/agents/builders/__tests__/registry.test.ts
@@ -44,7 +44,7 @@ function restoreEnvKeys(originals: Record<string, string | undefined>): void {
 
 describe('AGENT_REGISTRY', () => {
     it('has entries for all known agents', () => {
-        const agents: AgentType[] = ['claude', 'goose', 'aider', 'codex', 'copilot', 'gemini', 'grok', 'opencode', 'qwen', 'cursor', 'vibe', 'kimi', 'dns'];
+        const agents: AgentType[] = ['claude', 'goose', 'aider', 'codex', 'copilot', 'gemini', 'grok', 'opencode', 'qwen', 'cursor', 'vibe', 'kimi', 'dns', 'agy'];
         for (const agent of agents) {
             expect(AGENT_REGISTRY[agent]).toBeDefined();
         }
@@ -78,6 +78,23 @@ describe('GenericAgentBuilder via registry', () => {
             expect(command.args[1]).toBe(SCRIPT_PATH);
             expect(command.args[2]).toBe('gemini');
             expect(command.env?.GEMINI_API_KEY).toBe('test-gemini-key');
+        } finally {
+            if (origKey === undefined) delete process.env.GEMINI_API_KEY;
+            else process.env.GEMINI_API_KEY = origKey;
+        }
+    });
+
+    it('agy: uses print mode and skips permissions', async () => {
+        const origKey = process.env.GEMINI_API_KEY;
+        delete process.env.GEMINI_API_KEY;
+        try {
+            const builder = new GenericAgentBuilder(BASE_CONFIG, AGENT_REGISTRY.agy!);
+            const command = await builder.buildCommand('instructions');
+            expect(command.args.slice(0, 3)).toEqual(['bash', SCRIPT_PATH, 'agy']);
+            expect(command.args).toContain('--print');
+            expect(command.args).toContain('--dangerously-skip-permissions');
+            expect(command.args).not.toContain('--model');
+            expect(command.env).toEqual({});
         } finally {
             if (origKey === undefined) delete process.env.GEMINI_API_KEY;
             else process.env.GEMINI_API_KEY = origKey;

--- a/src/site/shared/__tests__/format.test.ts
+++ b/src/site/shared/__tests__/format.test.ts
@@ -9,6 +9,7 @@ describe('agentDisplayName', () => {
         expect(agentDisplayName('aider')).toBe('Aider');
         expect(agentDisplayName('gemini')).toBe('Gemini CLI');
         expect(agentDisplayName('grok')).toBe('Grok Build');
+        expect(agentDisplayName('agy')).toBe('Antigravity CLI');
         expect(agentDisplayName('qwen')).toBe('Qwen Code');
         expect(agentDisplayName('cursor')).toBe('Cursor Agent');
         expect(agentDisplayName('copilot')).toBe('GitHub Copilot CLI');

--- a/src/site/shared/format.ts
+++ b/src/site/shared/format.ts
@@ -21,6 +21,7 @@ export function agentDisplayName(slug: string): string {
         case 'aider': return 'Aider';
         case 'gemini': return 'Gemini CLI';
         case 'grok': return 'Grok Build';
+        case 'agy': return 'Antigravity CLI';
         case 'qwen': return 'Qwen Code';
         case 'cursor': return 'Cursor Agent';
         case 'copilot': return 'GitHub Copilot CLI';

--- a/src/utils/__tests__/version-detector.test.ts
+++ b/src/utils/__tests__/version-detector.test.ts
@@ -80,6 +80,11 @@ describe('VersionDetector', () => {
             const detector = makeDetector({ exitCode: 0, stdout: 'grok 0.1.0', stderr: '' });
             expect(await detector.detectAgentVersion('grok')).toBe('0.1.0');
         });
+
+        it('parses agy version from stdout', async () => {
+            const detector = makeDetector({ exitCode: 0, stdout: '1.1.13', stderr: '' });
+            expect(await detector.detectAgentVersion('agy')).toBe('1.1.13');
+        });
     });
 
     describe('detectAgentVersion – stderr fallback', () => {

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -72,6 +72,7 @@ Examples:
   ts-bench --agent goose --model gemini --save-result
   ts-bench --agent kimi --provider moonshot --model kimi-k2.5 --save-result
   ts-bench --agent grok --model grok-build-0.1 --save-result
+  ts-bench --agent agy --save-result
   bun src/index.ts --print-instructions --   acronym      # v1: show instructions for one exercise
   bun src/index.ts --setup-auth claude                    # authenticate Claude inside Docker
 

--- a/src/utils/version-detector.ts
+++ b/src/utils/version-detector.ts
@@ -109,6 +109,8 @@ export class VersionDetector {
                 return ['dsh', '--version'];
             case 'grok':
                 return ['grok', '--version'];
+            case 'agy':
+                return ['agy', '--version'];
             default:
                 throw new Error(`Unknown agent: ${agent}`);
         }


### PR DESCRIPTION
## Summary

Adds the `agy` agent — Google's Antigravity CLI — as a declarative config on
top of the config-driven agent registry (#123).

## Changes

1. **`config/agents/agy.yaml`** — the agent definition:
   - `defaultProvider: google`
   - curl install of the Antigravity CLI (`https://antigravity.google/cli/install.sh`)
   - command `agy --print "{instructions}" --dangerously-skip-permissions`
   - forwards `GEMINI_API_KEY` and the model as `AGY_MODEL`

2. **`scripts/run-agent.sh`** — `agy` branch installs the CLI on demand and,
   when `GEMINI_API_KEY` is set, writes
   `~/.gemini/antigravity-cli/settings.json` with
   `{"modelProvider": "gemini", "model": "<model>"}` (only if the file does not
   already exist) so the CLI talks to the Gemini API directly — no interactive
   sign-in needed. Without a key, the CLI falls back to its cached Google
   Sign-In (OAuth) login. The model comes from `AGY_MODEL` (ts-bench `--model`);
   when omitted, `"Gemini 3.7 Flash (High)"` is used because agy's own default
   resolution falls back to a non-agentic model.

3. **`src/utils/version-detector.ts`** — detect the version via `agy --version`.

4. **CI** — the v1 and v2 benchmark workflows accept `agy` (choice list,
   install step, availability check); `GEMINI_API_KEY` is already forwarded.

5. **Docs** — README, `specs/000-project-handbook/environment.md`, and CLI
   help updated for agy.

6. **Tests** — loader/registry/version-detector/format/v2-prompt-file coverage
   (print command shape, env passthrough, skip-permissions, no model flag).

## Verification (real GHA run)

`agy` solved the `accumulate` exercise end-to-end on GitHub Actions
(`--agent agy --provider google --model "Gemini 3.7 Flash (High)" --exercise 1`):

```
🤖 accumulate - Agent Success (70.1s)
🧪 accumulate - Test Success (6.9s)
✅ accumulate - Overall Success (77.2s)
🎯 Success Rate: 100.0% (1/1)
```

Notes from debugging against the real CLI (v1.1.13):

- The API-key mode requires `modelProvider: "gemini"` in
  `~/.gemini/antigravity-cli/settings.json` plus the `GEMINI_API_KEY` env var
  (the CLI's own error message confirms both).
- agy's model ids are display names with spaces (e.g. `"Gemini 3.7 Flash (High)"`),
  which the argument template cannot pass, so the model travels via the
  `AGY_MODEL` env into `settings.json`.
- Without a model in `settings.json`, the CLI falls back to a non-agentic
  model and every run fails — hence the explicit default.

## Other

- `bun test ./src`: 212 tests (5 new agy tests); the only failures are the
  pre-existing sandbox-only auth-cache tests that require `~/.cache` writes.
- `bun run typecheck`: identical to `main` (9 pre-existing errors, no new ones).
